### PR TITLE
리팩토링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, Pathname } from "react-router-dom";
 
 import {
   MainPage,
@@ -16,6 +16,22 @@ import GlobalStyle from "./styles/GlobalStyle";
 
 import AlbumPage from "./components/pages/AlbumPage";
 
+// 카멜 케이스로 작성 부탁해요
+export const pathName = {
+  home: "/",
+  signUp: "/signUp",
+  login: "/login",
+  album: "/album",
+  recentReview: "/album/recentReview",
+  mostReview: "/album/mostReview",
+  highestRated: "/album/highestRated",
+  albumDetail: "/albumDetail",
+  musicRecommendationBoard: "/musicRecommendationBoard",
+  board: "/board",
+} as const;
+
+export type PathType = (typeof pathName)[keyof typeof pathName];
+
 function App() {
   useAxiosInterceptors();
 
@@ -23,14 +39,23 @@ function App() {
     <>
       <GlobalStyle />
       <Routes>
-        <Route path="/" element={<MainPage />} />
-        <Route path="/signup" element={<SignUpPage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/recentreview" element={<RecentReview />} />
-        <Route path="/mostreview" element={<MostReview />} />
-        <Route path="/highestrated" element={<HighestRated />} />
-        <Route path="/album-detail/:id" element={<AlbumDetailPage />} />
-        <Route path="/album/*" element={<AlbumPage />} />
+        <Route path={pathName.home} element={<MainPage />}>
+          <Route path={pathName.musicRecommendationBoard} element={<>음추</>} />
+          <Route path={pathName.board} element={<>자유</>} />
+        </Route>
+
+        <Route path={pathName.signUp} element={<SignUpPage />} />
+        <Route path={pathName.login} element={<LoginPage />} />
+
+        <Route path={pathName.album} element={<AlbumPage />} />
+        <Route path={pathName.recentReview} element={<RecentReview />} />
+        <Route path={pathName.mostReview} element={<MostReview />} />
+        <Route path={pathName.highestRated} element={<HighestRated />} />
+
+        <Route
+          path={`${pathName.albumDetail}/:id`}
+          element={<AlbumDetailPage />}
+        />
       </Routes>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, Pathname } from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
 
 import {
   MainPage,
@@ -15,6 +15,7 @@ import { useAxiosInterceptors } from "./hooks";
 import GlobalStyle from "./styles/GlobalStyle";
 
 import AlbumPage from "./components/pages/AlbumPage";
+import { MainLayout } from "./components/common";
 
 // 카멜 케이스로 작성 부탁해요
 export const pathName = {
@@ -25,7 +26,6 @@ export const pathName = {
   recentReview: "/album/recentReview",
   mostReview: "/album/mostReview",
   highestRated: "/album/highestRated",
-  albumDetail: "/albumDetail",
   musicRecommendationBoard: "/musicRecommendationBoard",
   board: "/board",
 } as const;
@@ -39,23 +39,22 @@ function App() {
     <>
       <GlobalStyle />
       <Routes>
-        <Route path={pathName.home} element={<MainPage />}>
+        <Route path={"/"} element={<MainLayout />}>
+          <Route path={pathName.home} element={<MainPage />} />
+
+          <Route path={pathName.album} element={<AlbumPage />} />
+          <Route path={pathName.recentReview} element={<RecentReview />} />
+          <Route path={pathName.mostReview} element={<MostReview />} />
+          <Route path={pathName.highestRated} element={<HighestRated />} />
+
+          <Route path={`${pathName.album}/:id`} element={<AlbumDetailPage />} />
+
           <Route path={pathName.musicRecommendationBoard} element={<>음추</>} />
           <Route path={pathName.board} element={<>자유</>} />
         </Route>
 
         <Route path={pathName.signUp} element={<SignUpPage />} />
         <Route path={pathName.login} element={<LoginPage />} />
-
-        <Route path={pathName.album} element={<AlbumPage />} />
-        <Route path={pathName.recentReview} element={<RecentReview />} />
-        <Route path={pathName.mostReview} element={<MostReview />} />
-        <Route path={pathName.highestRated} element={<HighestRated />} />
-
-        <Route
-          path={`${pathName.albumDetail}/:id`}
-          element={<AlbumDetailPage />}
-        />
       </Routes>
     </>
   );

--- a/src/components/atoms/navbar/NavbarMenu.tsx
+++ b/src/components/atoms/navbar/NavbarMenu.tsx
@@ -2,13 +2,19 @@ import styled from "styled-components";
 import color from "../../../styles/color";
 import { glassEffectStyle } from "../../../styles/style";
 import { Link } from "react-router-dom";
+
 type MenuNameType = {
   title: string;
   link: string;
+  currentTab: string;
 };
 
-const NavbarMenu = ({ title, link }: MenuNameType) => {
-  return <StyledLink to={link}>{title}</StyledLink>;
+const NavbarMenu = ({ title, link, currentTab }: MenuNameType) => {
+  return (
+    <StyledLink to={link} className={link === currentTab ? "focused" : "none"}>
+      {title}
+    </StyledLink>
+  );
 };
 
 export default NavbarMenu;
@@ -27,6 +33,10 @@ const StyledLink = styled(Link)`
   padding: 0.6rem 0.9rem;
 
   &:hover {
-    ${glassEffectStyle({ bgColor: "#ffffff12" })};
+    ${glassEffectStyle({ bgColor: "rgba(255, 255, 255, 0.05)" })};
+  }
+
+  &.focused {
+    ${glassEffectStyle({ bgColor: "rgba(255, 255, 255, 0.2)" })};
   }
 `;

--- a/src/components/common/MainLayout.tsx
+++ b/src/components/common/MainLayout.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import styled from "styled-components";
 import color from "../../styles/color";
 
+import { Outlet } from "react-router-dom";
+
 import { useMediaQueries } from "../../hooks";
 
 import LogoImage from "./LogoImage";
@@ -10,11 +12,12 @@ import SearchBar from "../molecules/search/SearchBar";
 import DropDownNavigation from "../organisms/navbar/DropDownNavigation";
 
 import { useMemberInfoQuery } from "../../hooks/services/queries/userQueries";
+
 type Props = {
   children?: React.ReactNode;
 };
 
-const MainLayout = ({ children }: Props) => {
+const MainLayout = () => {
   const { isPc, isTablet } = useMediaQueries();
   const isLoggedIn = localStorage.getItem("loginState");
   const { data } = useMemberInfoQuery();
@@ -40,7 +43,9 @@ const MainLayout = ({ children }: Props) => {
               <SearchBar />
             </HeaderWrapper>
 
-            <Contents style={{ width: "80%" }}>{children}</Contents>
+            <Contents>
+              <Outlet />
+            </Contents>
           </ContentsWrapper>
         </>
       ) : (
@@ -57,7 +62,7 @@ const MainLayout = ({ children }: Props) => {
                 width: isTablet ? "80%" : "100%",
               }}
             >
-              {children}
+              <Outlet />
             </Contents>
           </ContentsWrapper>
         </>
@@ -69,7 +74,7 @@ const MainLayout = ({ children }: Props) => {
 export default MainLayout;
 
 const Layout = styled.div`
-  width: 100vw;
+  width: 100%;
   min-height: 100vh;
   display: flex;
 
@@ -103,6 +108,6 @@ const HeaderWrapper = styled.div`
 `;
 
 const Contents = styled.div`
-  width: 100%;
+  width: 80%;
   padding: 2rem 2rem 150px;
 `;

--- a/src/components/molecules/album/AlbumCard.tsx
+++ b/src/components/molecules/album/AlbumCard.tsx
@@ -26,7 +26,7 @@ const Container = styled.div`
   ${glassEffectStyle()}
   width: 100%;
   flex-shrink: 0;
-  border-radius: 0.5rem;
+  border-radius: 5px;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/components/molecules/album/AlbumInfo.tsx
+++ b/src/components/molecules/album/AlbumInfo.tsx
@@ -37,7 +37,7 @@ export default AlbumInfo;
 const Container = styled.div`
   ${glassEffectStyle()}
   width: 100%;
-  border-radius: 0.3rem;
+  border-radius: 5px;
   padding: 0.5rem;
   display: flex;
   flex-direction: column;
@@ -47,6 +47,7 @@ const Container = styled.div`
 
 const Wrapper = styled.div`
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
 `;

--- a/src/components/molecules/navbar/NavMenuList.tsx
+++ b/src/components/molecules/navbar/NavMenuList.tsx
@@ -1,19 +1,36 @@
+import { useEffect, useState } from "react";
+
 import styled from "styled-components";
 
 import NavbarMenu from "../../atoms/navbar/NavbarMenu";
 
-import { Link } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
-import { glassEffectStyle } from "../../../styles/style";
-import color from "../../../styles/color";
+import { pathName, PathType } from "../../../App";
 
 const NavMenuList = () => {
+  const [currentTab, setCurrentTab] = useState<PathType | string>("/");
+  const location = useLocation();
+
+  useEffect(() => {
+    let [_, path, ...rest] = location.pathname.split("/");
+    setCurrentTab(`/${path}`);
+  }, [location]);
+
   return (
     <MenuDiv>
-      <NavbarMenu title="홈" link="/" />
-      <NavbarMenu title="앨범" link="/album" />
-      <NavbarMenu title="음악 추천 게시판" link="/" />
-      <NavbarMenu title="자유 게시판" link="/" />
+      <NavbarMenu title="홈" link={pathName.home} currentTab={currentTab} />
+      <NavbarMenu title="앨범" link={pathName.album} currentTab={currentTab} />
+      <NavbarMenu
+        title="음악 추천 게시판"
+        link={pathName.musicRecommendationBoard}
+        currentTab={currentTab}
+      />
+      <NavbarMenu
+        title="자유 게시판"
+        link={pathName.board}
+        currentTab={currentTab}
+      />
     </MenuDiv>
   );
 };
@@ -26,19 +43,4 @@ const MenuDiv = styled.div`
   display: flex;
   align-items: center;
   flex-direction: column;
-`;
-
-const StyledLink = styled(Link)`
-  width: 100%;
-  font-size: 0.9rem;
-  font-weight: 700;
-  background-color: transparent;
-  text-align: start;
-  border-radius: 5px;
-  color: ${color.COLOR_DARKGRAY_TEXT};
-  white-space: nowrap;
-
-  &:hover {
-    ${glassEffectStyle({ bgColor: "#ffffff12" })};
-  }
 `;

--- a/src/components/molecules/search/SearchBar.tsx
+++ b/src/components/molecules/search/SearchBar.tsx
@@ -6,26 +6,27 @@ import { TbMusicSearch } from "react-icons/tb";
 
 import Input from "../../common/Input";
 
+import { pathName } from "../../../App";
+
 const SearchBar = () => {
   const [input, setInput] = useState<string>("");
-  
+
   const location = useLocation();
   const navigate = useNavigate();
-    
+
   const handleSearch = () => {
-    navigate(`/album/search?query=${input}`);
+    navigate(`${pathName.album}/search?query=${input}`);
   };
-    
+
   useEffect(() => {
     const query = new URLSearchParams(location.search).get("query");
-    
-    if(query) {
+
+    if (query) {
       setInput(query);
     } else {
       setInput("");
     }
   }, [location]);
-  
 
   return (
     <Input
@@ -34,7 +35,7 @@ const SearchBar = () => {
       placeholder={"평가할 앨범을 검색해 보세요!"}
       button={{
         icon: <TbMusicSearch size="1.2rem" />,
-        onClickButton: handleSearch
+        onClickButton: handleSearch,
       }}
       width="45%"
     />

--- a/src/components/molecules/search/SearchBar.tsx
+++ b/src/components/molecules/search/SearchBar.tsx
@@ -15,7 +15,7 @@ const SearchBar = () => {
   const navigate = useNavigate();
 
   const handleSearch = () => {
-    navigate(`${pathName.album}/search?query=${input}`);
+    navigate(`${pathName.album}?query=${input}`);
   };
 
   useEffect(() => {

--- a/src/components/organisms/album/AlbumCarousel.tsx
+++ b/src/components/organisms/album/AlbumCarousel.tsx
@@ -115,6 +115,7 @@ const Container = styled.div`
 `;
 
 const Carousel = styled.div`
+  width: 100%;
   display: flex;
   transition: 0.5s;
   gap: ${GAP_REM}rem;

--- a/src/components/organisms/album/AlbumSearchList.tsx
+++ b/src/components/organisms/album/AlbumSearchList.tsx
@@ -1,9 +1,14 @@
 import styled from "styled-components";
-import { AlbumCard, AlbumList } from "../../molecules";
-import { useMediaQueries } from "../../../hooks";
-import { glassEffectStyle } from "../../../styles/style";
+
 import { FaArrowLeft } from "react-icons/fa6";
 import { useNavigate } from "react-router-dom";
+
+import { AlbumCard, AlbumList } from "../../molecules";
+import { useMediaQueries } from "../../../hooks";
+
+import { glassEffectStyle } from "../../../styles/style";
+import { pathName } from "../../../App";
+
 const AlbumSearchList = ({ data, query }: any) => {
   if (!data) return <p>Loading...</p>;
   const { isPc, isTablet, isMobile } = useMediaQueries();
@@ -12,9 +17,11 @@ const AlbumSearchList = ({ data, query }: any) => {
   const topItems = data.slice(0, numToShow);
   const rest = data.slice(numToShow);
   const navigate = useNavigate();
+
   const handleClick = () => {
-    navigate("/album");
+    navigate(`${pathName.album}`);
   };
+
   return (
     <Container>
       <SearchTitle>

--- a/src/components/organisms/album/AlbumSection.tsx
+++ b/src/components/organisms/album/AlbumSection.tsx
@@ -4,7 +4,12 @@ import AlbumCarousel from "./AlbumCarousel";
 import { glassEffectStyle } from "../../../styles/style";
 import color from "../../../styles/color";
 
-const AlbumSection = ({ title, link }) => {
+type Props = {
+  title: string;
+  link: string;
+};
+
+const AlbumSection = ({ title, link }: Props) => {
   return (
     <Container>
       <Header>
@@ -19,16 +24,16 @@ const AlbumSection = ({ title, link }) => {
 export default AlbumSection;
 
 const Container = styled.div`
+  ${glassEffectStyle()}
   margin-top: 3rem;
   width: 100%;
+  box-sizing: border-box;
   display: flex;
-  padding: 0 2rem;
   flex-direction: column;
   justify-content: space-between;
-  gap: 2rem;
-  background-color: rgba(255, 255, 255, 0.2);
+  gap: 1rem;
+  padding: 1rem 1.5rem;
   border-radius: 10px;
-  padding-bottom: 1rem;
 `;
 
 const Header = styled.div`
@@ -41,12 +46,10 @@ const AlbumCategory = styled.div`
   font-size: 1.4rem;
   font-weight: bold;
   color: black;
-  padding-top: 2rem;
-  padding-bottom: 0rem;
-  margin: 0rem;
 `;
 
 const MoreBtn = styled(Link)`
+  ${glassEffectStyle()}
   display: flex;
   justify-content: center;
   align-items: center;
@@ -54,11 +57,10 @@ const MoreBtn = styled(Link)`
   font-weight: 700;
   color: ${color.COLOR_GRAY_TEXT};
   text-decoration: none; /* 밑줄 제거 */
-  ${glassEffectStyle()}
   padding: 0.5rem 1rem;
   border-radius: 20px;
   transition: 0.4s;
-  margin-top: 1rem;
+
   &:hover {
     background-color: ${color.COLOR_BLUE_AUTH_BUTTON};
     color: white;

--- a/src/components/organisms/auth/LoginForm.tsx
+++ b/src/components/organisms/auth/LoginForm.tsx
@@ -10,6 +10,7 @@ import { validationRules } from "../../../utils/auth/validationRules";
 import useLogin from "../../../hooks/useLogin";
 
 import { LoginType } from "../../../types/authTypes";
+import { pathName } from "../../../App";
 
 const LoginForm = () => {
   const {
@@ -35,7 +36,7 @@ const LoginForm = () => {
     } else {
       setErrorMessage("");
       alert("로그인에 성공했습니다.");
-      navigate("/"); // 로그인 성공 시 대시보드로 이동
+      navigate(`${pathName.home}`); // 로그인 성공 시 대시보드로 이동
     }
   };
   useEffect(() => {

--- a/src/components/organisms/auth/SignUpForm.tsx
+++ b/src/components/organisms/auth/SignUpForm.tsx
@@ -24,6 +24,8 @@ import {
 } from "../../../utils/auth/authApi";
 
 import { FormType } from "../../../types/authTypes";
+import { pathName } from "../../../App";
+
 const SignUpForm = () => {
   const {
     register,
@@ -96,7 +98,7 @@ const SignUpForm = () => {
       const result = await handleSubmitData(data);
       if (result === 200) {
         alert("회원가입을 완료하였습니다. 로그인 페이지로 이동합니다.");
-        navigate("/login");
+        navigate(`${pathName.login}`);
       }
     } catch (err) {
       console.log(err, "err");

--- a/src/components/organisms/post/HomePostList.tsx
+++ b/src/components/organisms/post/HomePostList.tsx
@@ -13,7 +13,7 @@ const HomePostList = (props: Props) => {
       <PostListHeader text={props.text} />
 
       <ListWrapper>
-        {[...new Array(5).fill(0)].map(idx => (
+        {[...new Array(5).fill(0)].map((_, idx) => (
           <PostListItem key={`postListItem${idx}`} />
         ))}
       </ListWrapper>

--- a/src/components/pages/AlbumDetailPage.tsx
+++ b/src/components/pages/AlbumDetailPage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 
-import { MainLayout } from "../common";
 import AlbumDetailTab from "../molecules/albumDetail/AlbumDetailTab";
 import AlbumDetailInfo from "../organisms/albumDetail/AlbumDetailInfo";
 import AlbumDetailReview from "../organisms/albumDetail/AlbumDetailReview";
@@ -44,7 +43,7 @@ const AlbumDetailPage = () => {
   if (currentTab === "") return null;
 
   return (
-    <MainLayout>
+    <>
       <AlbumDetailTab
         tabObj={tabObj}
         currentTab={currentTab}
@@ -53,7 +52,7 @@ const AlbumDetailPage = () => {
 
       {currentTab === "info" && <AlbumDetailInfo />}
       {currentTab === "review" && <AlbumDetailReview />}
-    </MainLayout>
+    </>
   );
 };
 

--- a/src/components/pages/AlbumDetailPage.tsx
+++ b/src/components/pages/AlbumDetailPage.tsx
@@ -27,7 +27,7 @@ const AlbumDetailPage = () => {
 
   const onClickTab = (key?: string) => {
     const path = key === "review" ? "?tab=review" : "";
-    navigate(`${pathName.albumDetail}/${id}${path}`);
+    navigate(`${pathName.album}/${id}${path}`);
   };
 
   useEffect(() => {

--- a/src/components/pages/AlbumDetailPage.tsx
+++ b/src/components/pages/AlbumDetailPage.tsx
@@ -10,6 +10,8 @@ import AlbumDetailReview from "../organisms/albumDetail/AlbumDetailReview";
 import { AlbumSearchList } from "../organisms/album";
 import AlbumSection from "../organisms/album/AlbumSection";
 
+import { pathName } from "../../App";
+
 const tabObj = {
   info: "기본 정보",
   review: "감상평",
@@ -26,7 +28,7 @@ const AlbumDetailPage = () => {
 
   const onClickTab = (key?: string) => {
     const path = key === "review" ? "?tab=review" : "";
-    navigate(`/album-detail/${id}${path}`);
+    navigate(`${pathName.albumDetail}/${id}${path}`);
   };
 
   useEffect(() => {

--- a/src/components/pages/AlbumPage.tsx
+++ b/src/components/pages/AlbumPage.tsx
@@ -1,8 +1,6 @@
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
-import { MainLayout } from "../common";
-
 import { useApi } from "../../hooks";
 
 import { AlbumSearchList } from "../organisms/album";
@@ -44,14 +42,14 @@ const AlbumPage = () => {
     if (statusCode !== 200) return <p>Error loading albums</p>;
   }
   return (
-    <MainLayout>
+    <>
       {query && data && (
         <AlbumSearchList query={query} data={data.items}></AlbumSearchList>
       )}
       <AlbumSection title="최근 평가된 앨범" link={pathName.recentReview} />
       <AlbumSection title="평가 많은 순" link={pathName.mostReview} />
       <AlbumSection title="평점 높은 순" link={pathName.highestRated} />
-    </MainLayout>
+    </>
   );
 };
 

--- a/src/components/pages/AlbumPage.tsx
+++ b/src/components/pages/AlbumPage.tsx
@@ -8,6 +8,9 @@ import { useApi } from "../../hooks";
 import { AlbumSearchList } from "../organisms/album";
 
 import AlbumSection from "../organisms/album/AlbumSection";
+
+import { pathName } from "../../App";
+
 const AlbumPage = () => {
   //   const { isPc } = useMediaQueries();
   const location = useLocation();
@@ -45,9 +48,9 @@ const AlbumPage = () => {
       {query && data && (
         <AlbumSearchList query={query} data={data.items}></AlbumSearchList>
       )}
-      <AlbumSection title="최근 평가된 앨범" link="/recentreview" />
-      <AlbumSection title="평가 많은 순" link="/mostreview" />
-      <AlbumSection title="평점 높은 순" link="/highestrated" />
+      <AlbumSection title="최근 평가된 앨범" link={pathName.recentReview} />
+      <AlbumSection title="평가 많은 순" link={pathName.mostReview} />
+      <AlbumSection title="평점 높은 순" link={pathName.highestRated} />
     </MainLayout>
   );
 };

--- a/src/components/pages/HighestRated.tsx
+++ b/src/components/pages/HighestRated.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-import { MainLayout } from "../common";
 
 import { glassEffectStyle } from "../../styles/style";
 import color from "../../styles/color";
@@ -10,7 +9,7 @@ import { IoArrowBack } from "react-icons/io5";
 
 const HighestRated = () => {
   return (
-    <MainLayout>
+    <>
       <Container>
         <Header>
           <BackBtn to="/album">
@@ -25,7 +24,7 @@ const HighestRated = () => {
           ))}
         </CardContainer>
       </Container>
-    </MainLayout>
+    </>
   );
 };
 

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -6,6 +6,8 @@ import { AlbumCarousel } from "../organisms/album";
 
 import { useMediaQueries } from "../../hooks";
 
+import { Outlet } from "react-router-dom";
+
 const MainPage = () => {
   const { isPc } = useMediaQueries();
 
@@ -17,6 +19,8 @@ const MainPage = () => {
         <HomePostList text="음악 추천 게시판" />
         <HomePostList text="자유 게시판" />
       </PostListWrapper>
+
+      <Outlet />
     </MainLayout>
   );
 };

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 
-import { MainLayout } from "../common";
 import { HomePostList } from "../organisms";
 import { AlbumCarousel } from "../organisms/album";
 
@@ -12,7 +11,7 @@ const MainPage = () => {
   const { isPc } = useMediaQueries();
 
   return (
-    <MainLayout>
+    <>
       <AlbumCarousel />
 
       <PostListWrapper style={isPc ? { flexDirection: "row" } : {}}>
@@ -21,7 +20,7 @@ const MainPage = () => {
       </PostListWrapper>
 
       <Outlet />
-    </MainLayout>
+    </>
   );
 };
 

--- a/src/components/pages/MostReview.tsx
+++ b/src/components/pages/MostReview.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-import { MainLayout } from "../common";
 
 import { glassEffectStyle } from "../../styles/style";
 import color from "../../styles/color";
@@ -10,7 +9,7 @@ import { IoArrowBack } from "react-icons/io5";
 
 const MostReview = () => {
   return (
-    <MainLayout>
+    <>
       <Container>
         <Header>
           <BackBtn to="/album">
@@ -25,7 +24,7 @@ const MostReview = () => {
           ))}
         </CardContainer>
       </Container>
-    </MainLayout>
+    </>
   );
 };
 

--- a/src/components/pages/RecentReview.tsx
+++ b/src/components/pages/RecentReview.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-import { MainLayout } from "../common";
 
 import { glassEffectStyle } from "../../styles/style";
 import color from "../../styles/color";
@@ -10,7 +9,7 @@ import { IoArrowBack } from "react-icons/io5";
 
 const RecentReview = () => {
   return (
-    <MainLayout>
+    <>
       <Container>
         <Header>
           <BackBtn to="/album">
@@ -25,7 +24,7 @@ const RecentReview = () => {
           ))}
         </CardContainer>
       </Container>
-    </MainLayout>
+    </>
   );
 };
 


### PR DESCRIPTION
1. path 관련 리팩토링
- 기존에 navigate 를 통해 페이지 이동 시, navigate 함수 내부에 경로 이름을 직접 입력했음
- 이것은 추후에 경로 이름이 변경될 시 유지보수에 매우 치명적!
- 이를 해결하기 위해 App.tsx 내부에 pathName 을 작성하고, 이를 import 해서 쓰는 방식으로 바꿨음
![image](https://github.com/sing-k/FE/assets/79265861/11cc0545-bfd3-4ef2-9b65-a4b1b192f318)
![image](https://github.com/sing-k/FE/assets/79265861/40c88d38-313a-4d2a-a903-34e3a8328dd2)

2. MainLayout 관련 리팩토링
- 기존에는 메인 레이아웃이 쓰이는 각 페이지마다 MainLayout 을 불러다가 사용
- 하지만 MainLayout 내부에는 내비게이션바와 검색창이 있음... 페이지를 이동할때마다 얘네를 싹 다 새로 그려준다는 것
- 따라서 메인 레이아웃이 쓰이는 페이지들을 <Route> 로 묶어서 넣었음
![image](https://github.com/sing-k/FE/assets/79265861/f591d61c-b073-4b67-8915-f0d4d33d3638)
