### PR TITLE
Feat/fetch album

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/styled-components": "5.1.34",
         "axios": "1.6.8",
         "chart.js": "4.4.3",
+        "dayjs": "1.11.11",
         "http-proxy-middleware": "3.0.0",
         "jwt-decode": "^4.0.0",
         "quill": "2.0.2",
@@ -3857,6 +3858,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -8975,6 +8981,11 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
+    },
+    "dayjs": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/styled-components": "5.1.34",
     "axios": "1.6.8",
     "chart.js": "4.4.3",
+    "dayjs": "1.11.11",
     "http-proxy-middleware": "3.0.0",
     "jwt-decode": "^4.0.0",
     "quill": "2.0.2",

--- a/src/api/album.ts
+++ b/src/api/album.ts
@@ -1,0 +1,44 @@
+import client from "../config/axios";
+
+const LIMIT = 10;
+
+const queryData = {
+  recent: {
+    endPoint: "recent",
+    queryName: "cursor-date",
+  },
+  averageScore: {
+    endPoint: "average-score",
+    queryName: "cursor-score",
+  },
+  reviewCount: {
+    endPoint: "review-count",
+    queryName: "cursor-review-count",
+  },
+} as const;
+
+type AlbumType = keyof typeof queryData;
+
+type Args = {
+  cursorId?: string;
+  cursorData?: string;
+  albumType: AlbumType;
+};
+
+export const getAlbumList = async (args: Args) => {
+  try {
+    let url = `/api/albums/list/${queryData[args.albumType].endPoint}?limit=${LIMIT}`;
+
+    if (args.cursorId && args.cursorData) {
+      url += `&cursor-id=${args.cursorId}&${queryData[args.albumType].queryName}=${args.cursorData}`;
+    }
+
+    const res = await client.get(url);
+
+    if (res.status === 200) {
+      return res.data;
+    }
+  } catch (err) {
+    console.log(`get album ${args.albumType} list error: `, err);
+  }
+};

--- a/src/api/albumDetail.ts
+++ b/src/api/albumDetail.ts
@@ -7,3 +7,11 @@ export const getAlbumDetail = async (albumId: string) => {
     return res.data.data;
   }
 };
+
+export const getAlbumReviewStatistic = async (albumId: string) => {
+  const res = await client.get(`/api/reviews/albums/${albumId}/statistics`);
+
+  if (res.status === 200) {
+    return res.data.data;
+  }
+};

--- a/src/api/albumDetail.ts
+++ b/src/api/albumDetail.ts
@@ -1,0 +1,9 @@
+import client from "../config/axios";
+
+export const getAlbumDetail = async (albumId: string) => {
+  const res = await client.get(`/api/albums/${albumId}`);
+
+  if (res.status === 200) {
+    return res.data.data;
+  }
+};

--- a/src/components/atoms/album/AlbumGenre.tsx
+++ b/src/components/atoms/album/AlbumGenre.tsx
@@ -2,11 +2,11 @@ import styled from "styled-components";
 
 import color from "../../../styles/color";
 
-const AlbumType = () => {
+const AlbumGenre = () => {
   return <Container>[앨범종류]</Container>;
 };
 
-export default AlbumType;
+export default AlbumGenre;
 
 const Container = styled.div`
   font-size: 0.7rem;

--- a/src/components/atoms/album/AlbumName.tsx
+++ b/src/components/atoms/album/AlbumName.tsx
@@ -1,7 +1,11 @@
 import styled from "styled-components";
 
-const AlbumName = ({ data }: any) => {
-  return <StyledName>{data?.name}</StyledName>;
+type Props = {
+  name: string;
+};
+
+const AlbumName = ({ name }: Props) => {
+  return <StyledName>{name}</StyledName>;
 };
 
 export default AlbumName;

--- a/src/components/atoms/album/AlbumRating.tsx
+++ b/src/components/atoms/album/AlbumRating.tsx
@@ -4,11 +4,15 @@ import { IoMusicalNotes } from "react-icons/io5";
 
 import color from "../../../styles/color";
 
-const AlbumRating = () => {
+type Props = {
+  averageScore: number;
+};
+
+const AlbumRating = ({ averageScore }: Props) => {
   return (
     <Container>
       <IoMusicalNotes className="icon" color={color.COLOR_MAIN} />
-      4.5
+      {averageScore}
     </Container>
   );
 };

--- a/src/components/atoms/album/AlbumRatingNum.tsx
+++ b/src/components/atoms/album/AlbumRatingNum.tsx
@@ -4,11 +4,15 @@ import { IoPersonSharp } from "react-icons/io5";
 
 import color from "../../../styles/color";
 
-const AlbumRatingNum = () => {
+type Props = {
+  count: number;
+};
+
+const AlbumRatingNum = ({ count }: Props) => {
   return (
     <Container>
       <IoPersonSharp color={color.COLOR_MAIN} />
-      12
+      {count}
     </Container>
   );
 };

--- a/src/components/atoms/album/ArtistName.tsx
+++ b/src/components/atoms/album/ArtistName.tsx
@@ -1,7 +1,11 @@
 import styled from "styled-components";
 
-const ArtistName = ({ data }: any) => {
-  return <Name>{data?.artists[0]?.name}</Name>;
+type Props = {
+  name: string;
+};
+
+const ArtistName = ({ name }: Props) => {
+  return <Name>{name}</Name>;
 };
 
 export default ArtistName;

--- a/src/components/atoms/album/index.ts
+++ b/src/components/atoms/album/index.ts
@@ -2,7 +2,7 @@ export { default as CoverImage } from "./CoverImage";
 export { default as Record } from "./Record";
 export { default as AlbumName } from "./AlbumName";
 export { default as AlbumRating } from "./AlbumRating";
-export { default as AlbumType } from "./AlbumType";
+export { default as AlbumGenre } from "./AlbumGenre";
 export { default as ArtistName } from "./ArtistName";
 export { default as AlbumRatingNum } from "./AlbumRatingNum";
 export { default as AlbumNameList } from "./AlbumNameList";

--- a/src/components/molecules/album/AlbumCardItem.tsx
+++ b/src/components/molecules/album/AlbumCardItem.tsx
@@ -1,18 +1,20 @@
 import styled from "styled-components";
 
+import { glassEffectStyle } from "../../../styles/style";
+
+import { AlbumType } from "../../../types/albumType";
+
 import CoverRecord from "./CoverRecord";
 import AlbumInfo from "./AlbumInfo";
 
-import { glassEffectStyle } from "../../../styles/style";
-
 type Props = {
   width?: string;
-  data?: any;
+  data: AlbumType;
 };
 
-const AlbumCard = ({ width, data }: Props) => {
+const AlbumCardItem = ({ width = "100%", data }: Props) => {
   return (
-    <Container style={width ? { width } : {}}>
+    <Container style={{ width }}>
       <CoverRecord data={data} />
 
       <AlbumInfo data={data} />
@@ -20,16 +22,16 @@ const AlbumCard = ({ width, data }: Props) => {
   );
 };
 
-export default AlbumCard;
+export default AlbumCardItem;
 
 const Container = styled.div`
   ${glassEffectStyle()}
   width: 100%;
-  flex-shrink: 0;
+  flex: 1;
   border-radius: 5px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   gap: 0.7rem;
   padding: 0.7rem;

--- a/src/components/molecules/album/AlbumInfo.tsx
+++ b/src/components/molecules/album/AlbumInfo.tsx
@@ -3,30 +3,35 @@ import styled from "styled-components";
 import {
   AlbumName,
   AlbumRating,
-  AlbumType,
   ArtistName,
   AlbumRatingNum,
+  AlbumGenre,
 } from "../../atoms";
 
 import { glassEffectStyle } from "../../../styles/style";
+import { AlbumType } from "../../../types/albumType";
 
-const AlbumInfo = ({ data }: any) => {
+type Props = {
+  data: AlbumType;
+};
+
+const AlbumInfo = ({ data }: Props) => {
   return (
     <Container>
       <Wrapper>
-        <AlbumName data={data} />
+        <AlbumName name={data.name} />
       </Wrapper>
 
       <Wrapper>
-        <ArtistName data={data} />
+        <ArtistName name={data.artists[0].name} />
 
-        <AlbumRating />
+        <AlbumRating averageScore={data.averageScore} />
       </Wrapper>
 
       <Wrapper>
-        <AlbumType />
+        <AlbumGenre />
 
-        <AlbumRatingNum />
+        <AlbumRatingNum count={data.count} />
       </Wrapper>
     </Container>
   );
@@ -39,9 +44,10 @@ const Container = styled.div`
   width: 100%;
   border-radius: 5px;
   padding: 0.5rem;
+  flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 0.5rem;
 `;
 

--- a/src/components/molecules/album/AlbumItem.tsx
+++ b/src/components/molecules/album/AlbumItem.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+import styled from "styled-components";
+
+import { useNavigate } from "react-router-dom";
+
+import { pathName } from "../../../App";
+
+import { AlbumType } from "../../../types/albumType";
+import { albumDummy } from "../../../dummy/album";
+
+import AlbumCardItem from "./AlbumCardItem";
+import AlbumListItem from "./AlbumListItem";
+
+type AlbumItemType = "card" | "list";
+
+type Props = {
+  type?: AlbumItemType;
+  data: AlbumType;
+  width?: string;
+  itemRef?: React.RefObject<HTMLDivElement>;
+};
+
+const AlbumItem = ({
+  type = "card",
+  data = albumDummy,
+  width = "100%",
+  itemRef,
+}: Props) => {
+  if (!data) return;
+
+  const navigate = useNavigate();
+
+  const goAlbumDetailPage = () => {
+    navigate(`${pathName.album}/${data.id}`);
+  };
+
+  return (
+    <Container ref={itemRef} style={{ width }} onClick={goAlbumDetailPage}>
+      {type === "card" ? (
+        <AlbumCardItem data={data} />
+      ) : type === "list" ? (
+        <AlbumListItem data={data} />
+      ) : null}
+    </Container>
+  );
+};
+
+export default AlbumItem;
+
+const Container = styled.div`
+  width: 100%;
+  flex: 1;
+  min-width: 150px;
+  display: flex;
+`;

--- a/src/components/molecules/album/AlbumListItem.tsx
+++ b/src/components/molecules/album/AlbumListItem.tsx
@@ -1,0 +1,81 @@
+import styled from "styled-components";
+
+import {
+  AlbumNameList,
+  ArtistName,
+  AlbumRating,
+  AlbumRatingNum,
+} from "../../atoms";
+
+import { AlbumType } from "../../../types/albumType";
+
+type Props = {
+  data: AlbumType;
+};
+
+const AlbumListItem = ({ data }: Props) => {
+  return (
+    <Container>
+      <Image src={data.images[0].imageUrl} alt={data.name} />
+
+      <LayOut>
+        <div>
+          <AlbumNameList data={data} />
+          <ArtistName name={data.artists[0].name} />
+        </div>
+
+        <div>
+          <AlbumRating averageScore={data.averageScore} />
+          <AlbumRatingNum count={data.count} />
+          <Button>평가하기</Button>
+        </div>
+      </LayOut>
+    </Container>
+  );
+};
+
+export default AlbumListItem;
+
+const Container = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: start;
+  align-items: center;
+  padding: 0.5rem 0;
+  cursor: pointer;
+  gap: 1rem;
+`;
+const Image = styled.img`
+  width: 10%;
+  aspect-ratio: 1 / 1;
+`;
+const LayOut = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  > div {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+  }
+`;
+const Button = styled.button`
+  /* font-size: 0.8rem; */
+  font-size: 1vw;
+  font-weight: 700;
+  border-radius: 20px;
+  padding: 0.4rem 1.2rem;
+  white-space: nowrap;
+  background-color: transparent;
+  color: white;
+  border: 1px solid white;
+
+  &:hover {
+    cursor: pointer;
+  }
+`;

--- a/src/components/molecules/album/CoverRecord.tsx
+++ b/src/components/molecules/album/CoverRecord.tsx
@@ -18,4 +18,5 @@ const Container = styled.div`
   width: 100%;
   aspect-ratio: 3 / 2;
   position: relative;
+  flex-shirnk: 0;
 `;

--- a/src/components/molecules/album/index.ts
+++ b/src/components/molecules/album/index.ts
@@ -1,3 +1,2 @@
-export { default as AlbumCard } from "./AlbumCard";
 export { default as CoverRecord } from "./CoverRecord";
 export { default as AlbumList } from "./AlbumList";

--- a/src/components/molecules/albumDetail/AlbumDetailInfoText.tsx
+++ b/src/components/molecules/albumDetail/AlbumDetailInfoText.tsx
@@ -1,6 +1,8 @@
 import styled from "styled-components";
 import color from "../../../styles/color";
 
+import { dateFormat } from "../../../utils/date";
+
 import StarRating from "../../atoms/albumDetail/StarRating";
 
 type Props = {
@@ -22,7 +24,7 @@ const AlbumDetailInfoText = (props: Props) => {
       <Box>
         <Wrapper>
           <Label>발매일</Label>
-          <Text>{props.releaseDate}</Text>
+          <Text>{dateFormat(props.releaseDate)}</Text>
         </Wrapper>
 
         <Wrapper>

--- a/src/components/molecules/albumDetail/AlbumGenderPercentage.tsx
+++ b/src/components/molecules/albumDetail/AlbumGenderPercentage.tsx
@@ -10,24 +10,48 @@ import { useMediaQueries } from "../../../hooks";
 
 import DashboardBox from "../../templates/albumDetail/DashboardBox";
 
+import { AlbumReviewStatisticType } from "../../../types/albumReviewStatisticType";
+
 Chart.register(ArcElement, Tooltip, Legend);
 
-const AlbumGenderPercentage = () => {
+type Props = {
+  data: AlbumReviewStatisticType;
+};
+
+const AlbumGenderPercentage = ({ data }: Props) => {
+  const { genderStatistics, count } = data;
+
+  genderStatistics.sort((a, _) => (a.gender === "남성" ? -1 : 1));
+
   const { isMobile } = useMediaQueries();
-  const data = useMemo(
-    () => ({
-      labels: ["여성", "남성"],
-      datasets: [
-        {
-          label: "# of Percentages",
-          data: [43, 57],
-          backgroundColor: [color.COLOR_FEMALE, color.COLOR_MALE],
-          borderColor: ["#ffffff", "#ffffff"],
-          borderWidth: 1,
-        },
-      ],
-    }),
-    []
+  const doughnutData = useMemo(
+    () =>
+      count === 0
+        ? {
+            labels: ["통계 없음"],
+            datasets: [
+              {
+                label: "통계 없음",
+                data: [100],
+                backgroundColor: [color.COLOR_LIGHTGRAY_BACKGROUND],
+                borderColor: ["#ffffff"],
+                borderWidth: 1,
+              },
+            ],
+          }
+        : {
+            labels: genderStatistics.map((el) => el.gender),
+            datasets: [
+              {
+                label: "# of Percentages",
+                data: genderStatistics.map((el) => el.ratio),
+                backgroundColor: [color.COLOR_FEMALE, color.COLOR_MALE],
+                borderColor: ["#ffffff", "#ffffff"],
+                borderWidth: 1,
+              },
+            ],
+          },
+    [data]
   );
 
   const options = useMemo(
@@ -46,7 +70,7 @@ const AlbumGenderPercentage = () => {
     <DashboardBox text="성별 비율">
       <Container id="container" style={{ width: isMobile ? "40%" : "70%" }}>
         <Doughnut
-          data={data}
+          data={doughnutData}
           options={options}
           width={"100%"}
           height={"100%"}
@@ -54,8 +78,18 @@ const AlbumGenderPercentage = () => {
 
         {/* 도넛 차트의 가운데 */}
         <CenterDiv>
-          <CenterText className="male">남성 57%</CenterText>
-          <CenterText className="female">여성 43%</CenterText>
+          {count === 0 ? (
+            <CenterText>통계 없음</CenterText>
+          ) : (
+            <>
+              <CenterText className="male">
+                남성 {genderStatistics[0].ratio}%
+              </CenterText>
+              <CenterText className="female">
+                여성 {genderStatistics[1].ratio}%
+              </CenterText>
+            </>
+          )}
         </CenterDiv>
       </Container>
     </DashboardBox>
@@ -78,15 +112,15 @@ const CenterDiv = styled.div`
   padding: 0.5rem;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
 `;
 
 const CenterText = styled.p`
-  width: 48%;
   font-size: 0.8rem;
-  //   background-color: aqua;
   text-align: center;
   font-weight: bold;
+  flex: 1;
+  color: ${color.COLOR_DARKGRAY_TEXT};
 
   &.male {
     color: ${color.COLOR_MALE};

--- a/src/components/molecules/albumDetail/AlbumReviewRating.tsx
+++ b/src/components/molecules/albumDetail/AlbumReviewRating.tsx
@@ -1,20 +1,21 @@
 import styled from "styled-components";
 import color from "../../../styles/color";
 
+import { AlbumReviewStatisticType } from "../../../types/albumReviewStatisticType";
+
 import DashboardBox from "../../templates/albumDetail/DashboardBox";
 import StarRating from "../../atoms/albumDetail/StarRating";
 
 type Props = {
-  rating: number;
-  reviewCount: number;
+  data: AlbumReviewStatisticType;
 };
 
-const AlbumReviewRating = ({ rating, reviewCount }: Props) => {
+const AlbumReviewRating = ({ data }: Props) => {
   return (
     <DashboardBox text="평점">
-      <RatingText>{rating} / 5</RatingText>
-      <StarRating rating={rating} />
-      <ReviewCountText>{reviewCount}명 참여</ReviewCountText>
+      <RatingText>{data.averageScore} / 5</RatingText>
+      <StarRating rating={data.averageScore} />
+      <ReviewCountText>{data.count}명 참여</ReviewCountText>
     </DashboardBox>
   );
 };

--- a/src/components/molecules/albumDetail/AlbumScorePercentage.tsx
+++ b/src/components/molecules/albumDetail/AlbumScorePercentage.tsx
@@ -1,40 +1,23 @@
+import { AlbumReviewStatisticType } from "../../../types/albumReviewStatisticType";
+
 import DashboardBox from "../../templates/albumDetail/DashboardBox";
 import EachScorePercentage from "./EachScorePercentage";
 
-const dummy = [
-  {
-    score: 1,
-    percentage: 0,
-  },
-  {
-    score: 2,
-    percentage: 0,
-  },
-  {
-    score: 3,
-    percentage: 0,
-  },
-  {
-    score: 4,
-    percentage: 23,
-  },
-  {
-    score: 5,
-    percentage: 77,
-  },
-];
+type Props = {
+  data: AlbumReviewStatisticType;
+};
 
-const AlbumScorePercentage = () => {
+const AlbumScorePercentage = ({ data }: Props) => {
   return (
     <DashboardBox text="점수별 비율">
-      {dummy
+      {data.scoreStatistics
         .slice()
         .reverse()
         .map((data) => (
           <EachScorePercentage
-            key={`${data.score}${data.percentage}`}
+            key={`${data.score}${data.ratio}`}
             score={data.score}
-            percentage={data.percentage}
+            percentage={data.ratio}
           />
         ))}
     </DashboardBox>

--- a/src/components/molecules/albumDetail/AlbumTrack.tsx
+++ b/src/components/molecules/albumDetail/AlbumTrack.tsx
@@ -5,31 +5,48 @@ import styled from "styled-components";
 import color from "../../../styles/color";
 import { glassEffectStyle } from "../../../styles/style";
 
+import { timeFormat } from "../../../utils/time";
+
 import { FaRegStopCircle, FaPlayCircle } from "react-icons/fa";
+import { TrackType } from "../../../types/albumDetailType";
+
+import TrackPlayerModal from "../../organisms/albumDetail/TrackPlayerModal";
 
 type Props = {
-  number: number;
+  track: TrackType;
 };
 
-const AlbumTrack = (props: Props) => {
-  const [isPlaying, setIsPlaying] = useState<boolean>(false);
+const AlbumTrack = ({ track }: Props) => {
+  const [modalVisible, setModalVisible] = useState<boolean>(false);
 
   const onClickPlayButton = useCallback(() => {
-    setIsPlaying(!isPlaying);
-  }, [isPlaying]);
+    setModalVisible(!modalVisible);
+  }, [modalVisible]);
 
   return (
-    <Container>
-      <Wrapper>
-        <Number>{props.number}</Number>
-        <TrackName>별의 하모니</TrackName>
-        <Artist>QWER (feat.춘식)</Artist>
-      </Wrapper>
+    <>
+      <Container>
+        <Wrapper>
+          <Number>{track.trackNumber}</Number>
+          <TrackName>{track.name}</TrackName>
+          <Artist>아티스트 이름</Artist>
+        </Wrapper>
 
-      <PlayButton onClick={onClickPlayButton}>
-        {isPlaying ? <FaRegStopCircle /> : <FaPlayCircle />}
-      </PlayButton>
-    </Container>
+        <Wrapper>
+          <Time>{timeFormat(track.duration)}</Time>
+
+          {track.playable && (
+            <PlayButton onClick={onClickPlayButton}>
+              {modalVisible ? <FaRegStopCircle /> : <FaPlayCircle />}
+            </PlayButton>
+          )}
+        </Wrapper>
+      </Container>
+
+      {track.playable && modalVisible && (
+        <TrackPlayerModal track={track} setModalVisible={setModalVisible} />
+      )}
+    </>
   );
 };
 
@@ -62,10 +79,19 @@ const TrackName = styled.p`
 
 const Artist = styled.p`
   color: ${color.COLOR_GRAY_TEXT};
+  font-size: 0.9rem;
+`;
+
+const Time = styled.p`
+  color: ${color.COLOR_GRAY_TEXT};
+  font-size: 0.8rem;
 `;
 
 const PlayButton = styled.div`
   cursor: pointer;
-  font-size: 1.2rem;
+  font-size: 1.5rem;
   color: ${color.COLOR_MAIN};
+  display: flex;
+  align-items: center;
+  jusitfy-content: center;
 `;

--- a/src/components/organisms/album/AlbumCarousel.tsx
+++ b/src/components/organisms/album/AlbumCarousel.tsx
@@ -3,11 +3,12 @@ import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { FaChevronCircleLeft, FaChevronCircleRight } from "react-icons/fa";
 
-import { AlbumCard } from "../../molecules";
+import AlbumItem from "../../molecules/album/AlbumItem";
 
 import { useMediaQueries } from "../../../hooks";
 
 import { AlbumType } from "../../../types/albumType";
+import { albumListDummy } from "../../../dummy/album";
 
 import color from "../../../styles/color";
 import { glassEffectStyle } from "../../../styles/style";
@@ -18,7 +19,7 @@ type Props = {
 
 const GAP_REM = 1;
 
-const AlbumCarousel = ({ items }: Props) => {
+const AlbumCarousel = ({ items = albumListDummy }: Props) => {
   const [itemWidth, setItemWidth] = useState<number>(0);
   const [currentIdx, setCurrentIdx] = useState<number>(0);
 
@@ -69,22 +70,14 @@ const AlbumCarousel = ({ items }: Props) => {
   return (
     <Container>
       <Carousel ref={carouselRef}>
-        {items.map((data, idx) => (
-          <CardWrapper
-            key={`albumcard${idx}`}
-            style={{
-              width: isPc
-                ? "17%"
-                : isTablet
-                  ? "30%"
-                  : isMobile
-                    ? "40%"
-                    : "100%",
-            }}
-            ref={itemRef}
-          >
-            <AlbumCard data={data} />
-          </CardWrapper>
+        {items.map((data) => (
+          <AlbumItem
+            key={data.id}
+            itemRef={itemRef}
+            type="card"
+            data={data}
+            width={isPc ? "17%" : isTablet ? "30%" : isMobile ? "40%" : "100%"}
+          />
         ))}
       </Carousel>
 
@@ -128,12 +121,6 @@ const Carousel = styled.div`
   &:hover {
     animation-play-state: paused;
   }
-`;
-
-const CardWrapper = styled.div`
-  width: 100%;
-  flex-shrink: 0;
-  min-width: 130px;
 `;
 
 const IndicatorWrapper = styled.div`

--- a/src/components/organisms/album/AlbumCarousel.tsx
+++ b/src/components/organisms/album/AlbumCarousel.tsx
@@ -7,13 +7,18 @@ import { AlbumCard } from "../../molecules";
 
 import { useMediaQueries } from "../../../hooks";
 
+import { AlbumType } from "../../../types/albumType";
+
 import color from "../../../styles/color";
 import { glassEffectStyle } from "../../../styles/style";
 
-const GAP_REM = 1;
-const data = [...new Array(10).fill(0)];
+type Props = {
+  items: AlbumType[];
+};
 
-const AlbumCarousel = () => {
+const GAP_REM = 1;
+
+const AlbumCarousel = ({ items }: Props) => {
   const [itemWidth, setItemWidth] = useState<number>(0);
   const [currentIdx, setCurrentIdx] = useState<number>(0);
 
@@ -24,11 +29,11 @@ const AlbumCarousel = () => {
   const { isPc, isTablet, isMobile } = useMediaQueries();
 
   const handleClickPrev = () => {
-    if (currentIdx === 0) setCurrentIdx(9);
+    if (currentIdx === 0) setCurrentIdx(items.length - 1);
     else setCurrentIdx(currentIdx - 1);
   };
   const handleClickNext = () => {
-    if (currentIdx === 9) setCurrentIdx(0);
+    if (currentIdx === items.length - 1) setCurrentIdx(0);
     else setCurrentIdx(currentIdx + 1);
   };
 
@@ -64,7 +69,7 @@ const AlbumCarousel = () => {
   return (
     <Container>
       <Carousel ref={carouselRef}>
-        {data.map((_, idx) => (
+        {items.map((data, idx) => (
           <CardWrapper
             key={`albumcard${idx}`}
             style={{
@@ -78,7 +83,7 @@ const AlbumCarousel = () => {
             }}
             ref={itemRef}
           >
-            <AlbumCard />
+            <AlbumCard data={data} />
           </CardWrapper>
         ))}
       </Carousel>
@@ -90,7 +95,7 @@ const AlbumCarousel = () => {
 
         <div style={{ overflow: "hidden" }}>
           <Indicator ref={indicatorRef}>
-            {data.map((_, idx) => (
+            {items.map((_, idx) => (
               <Dot
                 key={`${idx}indicator`}
                 className={idx === currentIdx ? "focused" : "none"}

--- a/src/components/organisms/album/AlbumSearchList.tsx
+++ b/src/components/organisms/album/AlbumSearchList.tsx
@@ -3,15 +3,25 @@ import styled from "styled-components";
 import { FaArrowLeft } from "react-icons/fa6";
 import { useNavigate } from "react-router-dom";
 
-import { AlbumCard, AlbumList } from "../../molecules";
 import { useMediaQueries } from "../../../hooks";
 
 import { glassEffectStyle } from "../../../styles/style";
 import { pathName } from "../../../App";
 
-const AlbumSearchList = ({ data, query }: any) => {
+import { AlbumType } from "../../../types/albumType";
+
+import AlbumCarousel from "./AlbumCarousel";
+import AlbumItem from "../../molecules/album/AlbumItem";
+
+type Props = {
+  data: AlbumType[];
+  query: string;
+};
+
+const AlbumSearchList = ({ data, query }: Props) => {
   if (!data) return <p>Loading...</p>;
-  const { isPc, isTablet, isMobile } = useMediaQueries();
+
+  const { isPc, isTablet } = useMediaQueries();
   const numToShow = isPc ? 5 : isTablet ? 3 : 2;
 
   const topItems = data.slice(0, numToShow);
@@ -27,18 +37,12 @@ const AlbumSearchList = ({ data, query }: any) => {
       <SearchTitle>
         <FaArrowLeft onClick={handleClick} /> '{query}'에 대한 검색 결과
       </SearchTitle>
-      <CardWrapper>
-        {topItems.map((data: any) => (
-          <AlbumCard
-            key={data.id}
-            data={data}
-            width={isPc ? "19%" : isTablet ? "30%" : isMobile ? "40%" : "100%"}
-          ></AlbumCard>
-        ))}
-      </CardWrapper>
+
+      <AlbumCarousel items={topItems} />
+
       <ListWrapper>
-        {rest.map((data: any) => (
-          <AlbumList key={data.id} data={data}></AlbumList>
+        {rest.map((data) => (
+          <AlbumItem key={data.id} type="list" data={data} />
         ))}
       </ListWrapper>
     </Container>
@@ -50,7 +54,7 @@ export default AlbumSearchList;
 const Container = styled.div`
   ${glassEffectStyle()}
   width: 100%;
-  padding: 2rem;
+  padding: 1rem 1.5rem;
   display: flex;
   justify-content: center;
   flex-direction: column;
@@ -64,12 +68,6 @@ const SearchTitle = styled.div`
   font-weight: 900;
 `;
 
-const CardWrapper = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: center; /* 가로 중앙 정렬 */
-  gap: 1rem;
-`;
 const ListWrapper = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/components/organisms/album/AlbumSection.tsx
+++ b/src/components/organisms/album/AlbumSection.tsx
@@ -1,22 +1,42 @@
+import { useEffect, useState } from "react";
+
 import styled from "styled-components";
+
 import { Link } from "react-router-dom";
+
 import AlbumCarousel from "./AlbumCarousel";
+
 import { glassEffectStyle } from "../../../styles/style";
 import color from "../../../styles/color";
+
+import { AlbumType } from "../../../types/albumType";
 
 type AlbumSectionType = {
   title: string;
   link: string;
+  fetchData: () => any;
 };
 
-const AlbumSection = ({ title, link }: AlbumSectionType) => {
+const AlbumSection = ({ title, link, fetchData }: AlbumSectionType) => {
+  const [items, setItems] = useState<AlbumType[]>();
+
+  useEffect(() => {
+    fetchData().then((res: any) => {
+      // console.log(res.data.items);
+      setItems(res.data.items as AlbumType[]);
+    });
+  }, [fetchData]);
+
+  if (!items) return;
+
   return (
     <Container>
       <Header>
         <AlbumCategory>{title}</AlbumCategory>
         <MoreBtn to={link}>더보기</MoreBtn>
       </Header>
-      <AlbumCarousel />
+
+      <AlbumCarousel items={items} />
     </Container>
   );
 };

--- a/src/components/organisms/albumDetail/AlbumDetailCard.tsx
+++ b/src/components/organisms/albumDetail/AlbumDetailCard.tsx
@@ -7,8 +7,17 @@ import Badge from "../../../assets/img/badge.svg";
 
 import { useMediaQueries } from "../../../hooks";
 
-const AlbumDetailCard = () => {
+import { AlbumDetailType } from "../../../types/albumDetailType";
+
+type Props = {
+  data: AlbumDetailType;
+};
+
+const AlbumDetailCard = ({ data }: Props) => {
+  const { images, type, name, artists, releasedAt } = data;
+
   const { isMobile } = useMediaQueries();
+
   return (
     <Container
       style={
@@ -21,16 +30,16 @@ const AlbumDetailCard = () => {
         style={{
           width: isMobile ? "50%" : "25%",
         }}
-        src="https://image.bugsm.co.kr/album/images/500/40940/4094086.jpg"
+        src={images[0].imageUrl}
       />
 
       <AlbumDetailInfoText
-        type={"EP"}
-        title={"Discord (TAK Remix)"}
-        artist={"QWER"}
-        releaseDate={"2024-01-01"}
+        type={type}
+        title={name}
+        artist={artists[0].name}
+        releaseDate={releasedAt}
         genre={"일렉트로닉"}
-        rating={3.5}
+        rating={3}
         reviewCount={10}
       />
 
@@ -49,7 +58,6 @@ const Container = styled.div`
   display: flex;
   align-items: center;
   gap: 1rem;
-  position: relative;
 `;
 
 const AlbumImage = styled.img`

--- a/src/components/organisms/albumDetail/AlbumDetailInfo.tsx
+++ b/src/components/organisms/albumDetail/AlbumDetailInfo.tsx
@@ -2,15 +2,21 @@ import React from "react";
 
 import styled from "styled-components";
 
+import { AlbumDetailType } from "../../../types/albumDetailType";
+
 import AlbumDetailCard from "./AlbumDetailCard";
 import AlbumTrackList from "./AlbumTrackList";
 
-const AlbumDetailInfo = () => {
+type Props = {
+  data: AlbumDetailType;
+};
+
+const AlbumDetailInfo = ({ data }: Props) => {
   return (
     <Container>
-      <AlbumDetailCard />
+      <AlbumDetailCard data={data} />
 
-      <AlbumTrackList />
+      <AlbumTrackList tracks={data.tracks} />
     </Container>
   );
 };

--- a/src/components/organisms/albumDetail/AlbumDetailInfo.tsx
+++ b/src/components/organisms/albumDetail/AlbumDetailInfo.tsx
@@ -2,16 +2,21 @@ import React from "react";
 
 import styled from "styled-components";
 
-import { AlbumDetailType } from "../../../types/albumDetailType";
+import { useAlbumDetailQuery } from "../../../hooks/queries/albumDetail";
 
 import AlbumDetailCard from "./AlbumDetailCard";
 import AlbumTrackList from "./AlbumTrackList";
 
 type Props = {
-  data: AlbumDetailType;
+  albumId: string;
 };
 
-const AlbumDetailInfo = ({ data }: Props) => {
+const AlbumDetailInfo = ({ albumId }: Props) => {
+  const { data, isLoading, isError, error } = useAlbumDetailQuery(albumId);
+
+  if (isLoading) return <>로딩중 {"><"}</>;
+  if (isError) return <>미친 에러 {error.message}</>;
+
   return (
     <Container>
       <AlbumDetailCard data={data} />

--- a/src/components/organisms/albumDetail/AlbumDetailReview.tsx
+++ b/src/components/organisms/albumDetail/AlbumDetailReview.tsx
@@ -6,10 +6,14 @@ import AlbumReviewDashboard from "./AlbumReviewDashboard";
 import AlbumReviewInput from "./AlbumReviewInput";
 import AlbumReviewList from "./AlbumReviewList";
 
-const AlbumDetailReview = () => {
+type Props = {
+  albumId: string;
+};
+
+const AlbumDetailReview = ({ albumId }: Props) => {
   return (
     <Container>
-      <AlbumReviewDashboard />
+      <AlbumReviewDashboard albumId={albumId} />
 
       <AlbumReviewInput />
 

--- a/src/components/organisms/albumDetail/AlbumReviewDashboard.tsx
+++ b/src/components/organisms/albumDetail/AlbumReviewDashboard.tsx
@@ -2,18 +2,30 @@ import styled from "styled-components";
 
 import { glassEffectStyle } from "../../../styles/style";
 
+import { useAlbumReviewStatisticQuery } from "../../../hooks/queries/albumDetail";
+
 import AlbumReviewRating from "../../molecules/albumDetail/AlbumReviewRating";
 import AlbumScorePercentage from "../../molecules/albumDetail/AlbumScorePercentage";
 import AlbumGenderPercentage from "../../molecules/albumDetail/AlbumGenderPercentage";
 
-const AlbumReviewDashboard = () => {
+type Props = {
+  albumId: string;
+};
+
+const AlbumReviewDashboard = ({ albumId }: Props) => {
+  const { data, isLoading, isError, error } =
+    useAlbumReviewStatisticQuery(albumId);
+
+  if (isLoading) return <>로딩중 {"><"}</>;
+  if (isError) return <>미친 에러 {error.message}</>;
+
   return (
     <Container>
-      <AlbumReviewRating rating={4.5} reviewCount={123} />
+      <AlbumReviewRating data={data} />
 
-      <AlbumScorePercentage />
+      <AlbumScorePercentage data={data} />
 
-      <AlbumGenderPercentage />
+      <AlbumGenderPercentage data={data} />
     </Container>
   );
 };

--- a/src/components/organisms/albumDetail/AlbumTrackList.tsx
+++ b/src/components/organisms/albumDetail/AlbumTrackList.tsx
@@ -1,24 +1,34 @@
 import styled from "styled-components";
 
-import { glassEffectStyle } from "../../../styles/style";
+import { TrackType } from "../../../types/albumDetailType";
+
+import color from "../../../styles/color";
 
 import AlbumTrack from "../../molecules/albumDetail/AlbumTrack";
 
-const AlbumTrackList = () => {
+type Props = {
+  tracks: TrackType[];
+};
+
+const AlbumTrackList = ({ tracks }: Props) => {
+  tracks.sort((a, b) => a.trackNumber - b.trackNumber);
+
   return (
-    <Container>
-      <Text>Track List</Text>
-      {[...Array(5)].map((_, idx) => (
-        <AlbumTrack key={idx} number={idx + 1} />
-      ))}
-    </Container>
+    <>
+      <Container>
+        <Text>Track List</Text>
+        {tracks.map((track) => (
+          <AlbumTrack key={track.id} track={track} />
+        ))}
+      </Container>
+    </>
   );
 };
 
 export default AlbumTrackList;
 
 const Container = styled.div`
-  ${glassEffectStyle()}
+  background-color: ${color.COLOR_TRANSPARENT_WHITE};
   width: 100%;
   padding: 1rem;
   margin-top: 1rem;

--- a/src/components/organisms/albumDetail/TrackPlayerModal.tsx
+++ b/src/components/organisms/albumDetail/TrackPlayerModal.tsx
@@ -1,0 +1,214 @@
+import React, {
+  useRef,
+  MouseEvent,
+  useState,
+  useCallback,
+  useEffect,
+} from "react";
+
+import styled from "styled-components";
+
+import { IoMdClose } from "react-icons/io";
+import { FaRegStopCircle, FaPlayCircle } from "react-icons/fa";
+
+import { TrackType } from "../../../types/albumDetailType";
+import color from "../../../styles/color";
+import { useMediaQueries } from "../../../hooks";
+
+type Props = {
+  setModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  track: TrackType;
+};
+
+const TrackPlayerModal = ({ track, setModalVisible }: Props) => {
+  const [isPlaying, setIsPlaying] = useState<boolean>(true);
+  const [progress, setProgress] = useState<number>(0);
+
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const progressRef = useRef<HTMLDivElement>(null);
+
+  const { isMobile } = useMediaQueries();
+
+  const closeModal = (e: MouseEvent<any>) => {
+    if (e.target === e.currentTarget) {
+      setModalVisible(false);
+    }
+  };
+
+  const onClickPlayButton = useCallback(() => {
+    if (audioRef.current) {
+      if (isPlaying) {
+        audioRef.current.pause();
+      } else {
+        audioRef.current.play();
+      }
+
+      setIsPlaying(!isPlaying);
+    }
+  }, [isPlaying]);
+
+  const onTimeUpdate = () => {
+    if (audioRef.current) {
+      const currentProgress =
+        (audioRef.current.currentTime / audioRef.current.duration) * 100;
+      setProgress(currentProgress);
+    }
+  };
+
+  const onEnded = () => {
+    if (progressRef.current) {
+      setIsPlaying(false);
+      setProgress(0);
+    }
+  };
+
+  useEffect(() => {
+    if (progressRef.current) {
+      progressRef.current.style.transform = `translateX(${progress - 100}%)`;
+    }
+  }, [progress]);
+
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.play();
+    }
+  }, []);
+
+  return (
+    <Container onClick={closeModal}>
+      <audio
+        style={{ display: "none" }}
+        ref={audioRef}
+        src={track.previewUrl}
+        onTimeUpdate={onTimeUpdate}
+        onEnded={onEnded}
+      />
+
+      <Modal
+        style={{
+          width: isMobile ? "80%" : "50%",
+        }}
+      >
+        <Wrapper>
+          <Text>미리듣기 중...</Text>
+          <CloseBtn onClick={closeModal} />
+        </Wrapper>
+
+        <PlayBtnWrapper>
+          <TrackName>{track.name}</TrackName>
+
+          <PlayBtn onClick={onClickPlayButton}>
+            {isPlaying ? <FaRegStopCircle /> : <FaPlayCircle />}
+          </PlayBtn>
+        </PlayBtnWrapper>
+
+        <Wrapper>
+          <ProgressBar>
+            <Progress ref={progressRef} />
+          </ProgressBar>
+
+          <Duration>
+            {audioRef.current ? (
+              <>
+                0:
+                {Math.floor(audioRef.current.currentTime as number)}
+                /0:{Math.floor(audioRef.current.duration as number)}
+              </>
+            ) : (
+              "0:00/0:00"
+            )}
+          </Duration>
+        </Wrapper>
+      </Modal>
+    </Container>
+  );
+};
+
+export default TrackPlayerModal;
+
+const Container = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.2);
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Modal = styled.div`
+  background-color: white;
+  padding: 2rem;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Text = styled.p`
+  font-size: 0.9rem;
+  font-weight: bold;
+  color: ${color.COLOR_GRAY_TEXT};
+`;
+
+const CloseBtn = styled(IoMdClose)`
+  cursor: pointer;
+  font-size: 1.2rem;
+`;
+
+const PlayBtnWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+`;
+
+const TrackName = styled.p`
+  font-weight: bold;
+  font-size: 1.5rem;
+`;
+
+const PlayBtn = styled.div`
+  cursor: pointer;
+  color: ${color.COLOR_MAIN};
+  font-size: 1.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ProgressBar = styled.div`
+  flex: 1;
+  height: 10px;
+  border-radius: 10px;
+  background-color: ${color.COLOR_LIGHTGRAY_BACKGROUND};
+  overflow: hidden;
+`;
+
+const Progress = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: ${color.COLOR_MAIN};
+  border-radius: inherit;
+  transition: 1s;
+  transform: translateX(-100%);
+`;
+
+const Duration = styled.p`
+  font-size: 0.8rem;
+  width: calc(0.8rem * 6);
+  color: ${color.COLOR_GRAY_TEXT};
+  text-align: end;
+`;

--- a/src/components/pages/AlbumDetailPage.tsx
+++ b/src/components/pages/AlbumDetailPage.tsx
@@ -7,7 +7,6 @@ import AlbumDetailReview from "../organisms/albumDetail/AlbumDetailReview";
 import TabMenu from "../common/TabMenu";
 
 import { pathName } from "../../App";
-import { useAlbumDetailQuery } from "../../hooks/queries/albumDetail";
 
 const tabObj = {
   info: "기본 정보",
@@ -22,7 +21,6 @@ const AlbumDetailPage = () => {
   const navigate = useNavigate();
 
   const [currentTab, setCurrentTab] = useState<TabKey | "">("");
-  const { data, isLoading, isError, error } = useAlbumDetailQuery(id as string);
 
   const onClickTab = (key?: string) => {
     const path = key === "review" ? "?tab=review" : "";
@@ -41,9 +39,6 @@ const AlbumDetailPage = () => {
 
   if (currentTab === "") return null;
 
-  if (isLoading) return <>로딩중 {"><"}</>;
-  if (isError) return <>미친 에러 {error.message}</>;
-
   return (
     <>
       <TabMenu
@@ -52,8 +47,8 @@ const AlbumDetailPage = () => {
         onClickTab={onClickTab}
       />
 
-      {currentTab === "info" && data && <AlbumDetailInfo data={data} />}
-      {currentTab === "review" && <AlbumDetailReview />}
+      {currentTab === "info" && <AlbumDetailInfo albumId={id as string} />}
+      {currentTab === "review" && <AlbumDetailReview albumId={id as string} />}
     </>
   );
 };

--- a/src/components/pages/AlbumDetailPage.tsx
+++ b/src/components/pages/AlbumDetailPage.tsx
@@ -7,6 +7,7 @@ import AlbumDetailReview from "../organisms/albumDetail/AlbumDetailReview";
 import TabMenu from "../common/TabMenu";
 
 import { pathName } from "../../App";
+import { useAlbumDetailQuery } from "../../hooks/queries/albumDetail";
 
 const tabObj = {
   info: "기본 정보",
@@ -21,6 +22,7 @@ const AlbumDetailPage = () => {
   const navigate = useNavigate();
 
   const [currentTab, setCurrentTab] = useState<TabKey | "">("");
+  const { data, isLoading, isError, error } = useAlbumDetailQuery(id as string);
 
   const onClickTab = (key?: string) => {
     const path = key === "review" ? "?tab=review" : "";
@@ -39,6 +41,9 @@ const AlbumDetailPage = () => {
 
   if (currentTab === "") return null;
 
+  if (isLoading) return <>로딩중 {"><"}</>;
+  if (isError) return <>미친 에러 {error.message}</>;
+
   return (
     <>
       <TabMenu
@@ -47,7 +52,7 @@ const AlbumDetailPage = () => {
         onClickTab={onClickTab}
       />
 
-      {currentTab === "info" && <AlbumDetailInfo />}
+      {currentTab === "info" && data && <AlbumDetailInfo data={data} />}
       {currentTab === "review" && <AlbumDetailReview />}
     </>
   );

--- a/src/components/pages/AlbumPage.tsx
+++ b/src/components/pages/AlbumPage.tsx
@@ -10,6 +10,8 @@ import AlbumSection from "../organisms/album/AlbumSection";
 
 import { pathName } from "../../App";
 
+import { AlbumType } from "../../types/albumType";
+
 const AlbumPage = () => {
   //   const { isPc } = useMediaQueries();
   const location = useLocation();
@@ -45,8 +47,12 @@ const AlbumPage = () => {
   return (
     <>
       {query && data && (
-        <AlbumSearchList query={query} data={data.items}></AlbumSearchList>
+        <AlbumSearchList
+          query={query}
+          data={data.items as AlbumType[]}
+        ></AlbumSearchList>
       )}
+
       <AlbumSection
         title="최근 평가된 앨범"
         link={pathName.recentReview}

--- a/src/components/pages/AlbumPage.tsx
+++ b/src/components/pages/AlbumPage.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
 import { useApi } from "../../hooks";
+import { getAlbumList } from "../../api/album";
 
 import { AlbumSearchList } from "../organisms/album";
 
@@ -46,9 +47,21 @@ const AlbumPage = () => {
       {query && data && (
         <AlbumSearchList query={query} data={data.items}></AlbumSearchList>
       )}
-      <AlbumSection title="최근 평가된 앨범" link={pathName.recentReview} />
-      <AlbumSection title="평가 많은 순" link={pathName.mostReview} />
-      <AlbumSection title="평점 높은 순" link={pathName.highestRated} />
+      <AlbumSection
+        title="최근 평가된 앨범"
+        link={pathName.recentReview}
+        fetchData={getAlbumList.bind(this, { albumType: "recent" })}
+      />
+      <AlbumSection
+        title="평가 많은 순"
+        link={pathName.mostReview}
+        fetchData={getAlbumList.bind(this, { albumType: "reviewCount" })}
+      />
+      <AlbumSection
+        title="평점 높은 순"
+        link={pathName.highestRated}
+        fetchData={getAlbumList.bind(this, { albumType: "averageScore" })}
+      />
     </>
   );
 };

--- a/src/components/pages/HighestRated.tsx
+++ b/src/components/pages/HighestRated.tsx
@@ -3,7 +3,6 @@ import { Link } from "react-router-dom";
 
 import { glassEffectStyle } from "../../styles/style";
 import color from "../../styles/color";
-import { AlbumCard } from "../molecules/album";
 
 import { IoArrowBack } from "react-icons/io5";
 
@@ -19,9 +18,9 @@ const HighestRated = () => {
         </Header>
 
         <CardContainer>
-          {Array.from({ length: 24 }).map((_, index) => (
-            <AlbumCard key={index} />
-          ))}
+          {/* {Array.from({ length: 24 }).map((_, index) => (
+            <AlbumCardItem key={index} />
+          ))} */}
         </CardContainer>
       </Container>
     </>

--- a/src/components/pages/HighestRated.tsx
+++ b/src/components/pages/HighestRated.tsx
@@ -1,83 +1,11 @@
-import styled from "styled-components";
-import { Link } from "react-router-dom";
-
-import { glassEffectStyle } from "../../styles/style";
-import color from "../../styles/color";
-
-import { IoArrowBack } from "react-icons/io5";
+import AlbumPageTemplate from "../templates/album/AlbumPageTemplate";
 
 const HighestRated = () => {
   return (
     <>
-      <Container>
-        <Header>
-          <BackBtn to="/album">
-            <IoArrowBack />
-          </BackBtn>
-          <AlbumCategory>평점 높은 순</AlbumCategory>
-        </Header>
-
-        <CardContainer>
-          {/* {Array.from({ length: 24 }).map((_, index) => (
-            <AlbumCardItem key={index} />
-          ))} */}
-        </CardContainer>
-      </Container>
+      <AlbumPageTemplate category="평점 높은 순"></AlbumPageTemplate>
     </>
   );
 };
 
 export default HighestRated;
-
-const Container = styled.div`
-  margin-top: 3rem;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 1rem;
-  background-color: rgba(255, 255, 255, 0.2);
-  border-radius: 10px;
-  padding: 0 2rem;
-  padding-bottom: 1rem;
-  margin-top: 1rem;
-`;
-
-const Header = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1rem; /* 추가: BackBtn과 AlbumCategory 사이에 간격을 추가 */
-  padding-bottom: 0;
-`;
-
-const AlbumCategory = styled.div`
-  font-size: 1.4rem;
-  font-weight: bold;
-  color: black;
-  padding-top: 1rem;
-`;
-
-const BackBtn = styled(Link)`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 0.8rem;
-  font-weight: 700;
-  color: ${color.COLOR_GRAY_TEXT};
-  ${glassEffectStyle()}
-  padding: 0.5rem 1rem;
-  border-radius: 20px;
-  transition: 0.4s;
-  margin-top: 1rem;
-  &:hover {
-    background-color: ${color.COLOR_BLUE_AUTH_BUTTON};
-    color: white;
-  }
-`;
-
-const CardContainer = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 1rem;
-  width: 100%;
-`;

--- a/src/components/pages/HighestRated.tsx
+++ b/src/components/pages/HighestRated.tsx
@@ -17,7 +17,7 @@ const HighestRated = () => {
           </BackBtn>
           <AlbumCategory>평점 높은 순</AlbumCategory>
         </Header>
-        {/* <AlbumCarousel /> */}
+
         <CardContainer>
           {Array.from({ length: 24 }).map((_, index) => (
             <AlbumCard key={index} />

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -7,12 +7,14 @@ import { useMediaQueries } from "../../hooks";
 
 import { Outlet } from "react-router-dom";
 
+import { albumListDummy } from "../../dummy/album";
+
 const MainPage = () => {
   const { isPc } = useMediaQueries();
 
   return (
     <>
-      {/* <AlbumCarousel /> */}
+      <AlbumCarousel items={albumListDummy} />
 
       <PostListWrapper style={isPc ? { flexDirection: "row" } : {}}>
         <HomePostList text="음악 추천 게시판" />

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -12,7 +12,7 @@ const MainPage = () => {
 
   return (
     <>
-      <AlbumCarousel />
+      {/* <AlbumCarousel /> */}
 
       <PostListWrapper style={isPc ? { flexDirection: "row" } : {}}>
         <HomePostList text="음악 추천 게시판" />

--- a/src/components/pages/MostReview.tsx
+++ b/src/components/pages/MostReview.tsx
@@ -17,7 +17,7 @@ const MostReview = () => {
           </BackBtn>
           <AlbumCategory>평가 많은 순</AlbumCategory>
         </Header>
-        {/* <AlbumCarousel /> */}
+
         <CardContainer>
           {Array.from({ length: 24 }).map((_, index) => (
             <AlbumCard key={index} />

--- a/src/components/pages/MostReview.tsx
+++ b/src/components/pages/MostReview.tsx
@@ -3,7 +3,6 @@ import { Link } from "react-router-dom";
 
 import { glassEffectStyle } from "../../styles/style";
 import color from "../../styles/color";
-import { AlbumCard } from "../molecules/album";
 
 import { IoArrowBack } from "react-icons/io5";
 
@@ -19,9 +18,9 @@ const MostReview = () => {
         </Header>
 
         <CardContainer>
-          {Array.from({ length: 24 }).map((_, index) => (
-            <AlbumCard key={index} />
-          ))}
+          {/* {Array.from({ length: 24 }).map((_, index) => (
+            <AlbumCardItem key={index} />
+          ))} */}
         </CardContainer>
       </Container>
     </>

--- a/src/components/pages/MostReview.tsx
+++ b/src/components/pages/MostReview.tsx
@@ -1,83 +1,11 @@
-import styled from "styled-components";
-import { Link } from "react-router-dom";
-
-import { glassEffectStyle } from "../../styles/style";
-import color from "../../styles/color";
-
-import { IoArrowBack } from "react-icons/io5";
+import AlbumPageTemplate from "../templates/album/AlbumPageTemplate";
 
 const MostReview = () => {
   return (
     <>
-      <Container>
-        <Header>
-          <BackBtn to="/album">
-            <IoArrowBack />
-          </BackBtn>
-          <AlbumCategory>평가 많은 순</AlbumCategory>
-        </Header>
-
-        <CardContainer>
-          {/* {Array.from({ length: 24 }).map((_, index) => (
-            <AlbumCardItem key={index} />
-          ))} */}
-        </CardContainer>
-      </Container>
+      <AlbumPageTemplate category="평가 많은 순"></AlbumPageTemplate>
     </>
   );
 };
 
 export default MostReview;
-
-const Container = styled.div`
-  margin-top: 3rem;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 1rem;
-  background-color: rgba(255, 255, 255, 0.2);
-  border-radius: 10px;
-  padding: 0 2rem;
-  padding-bottom: 1rem;
-  margin-top: 1rem;
-`;
-
-const Header = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1rem; /* 추가: BackBtn과 AlbumCategory 사이에 간격을 추가 */
-  padding-bottom: 0;
-`;
-
-const AlbumCategory = styled.div`
-  font-size: 1.4rem;
-  font-weight: bold;
-  color: black;
-  padding-top: 1rem;
-`;
-
-const BackBtn = styled(Link)`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 0.8rem;
-  font-weight: 700;
-  color: ${color.COLOR_GRAY_TEXT};
-  ${glassEffectStyle()}
-  padding: 0.5rem 1rem;
-  border-radius: 20px;
-  transition: 0.4s;
-  margin-top: 1rem;
-  &:hover {
-    background-color: ${color.COLOR_BLUE_AUTH_BUTTON};
-    color: white;
-  }
-`;
-
-const CardContainer = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 1rem;
-  width: 100%;
-`;

--- a/src/components/pages/RecentReview.tsx
+++ b/src/components/pages/RecentReview.tsx
@@ -1,83 +1,11 @@
-import styled from "styled-components";
-import { Link } from "react-router-dom";
-
-import { glassEffectStyle } from "../../styles/style";
-import color from "../../styles/color";
-
-import { IoArrowBack } from "react-icons/io5";
+import AlbumPageTemplate from "../templates/album/AlbumPageTemplate";
 
 const RecentReview = () => {
   return (
     <>
-      <Container>
-        <Header>
-          <BackBtn to="/album">
-            <IoArrowBack />
-          </BackBtn>
-          <AlbumCategory>최근 평가된 앨범</AlbumCategory>
-        </Header>
-
-        <CardContainer>
-          {/* {Array.from({ length: 24 }).map((_, index) => (
-            <AlbumCardItem key={index} />
-          ))} */}
-        </CardContainer>
-      </Container>
+      <AlbumPageTemplate category="최근 평가된 앨범"></AlbumPageTemplate>
     </>
   );
 };
 
 export default RecentReview;
-
-const Container = styled.div`
-  margin-top: 3rem;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 1rem;
-  background-color: rgba(255, 255, 255, 0.2);
-  border-radius: 10px;
-  padding: 0 2rem;
-  padding-bottom: 1rem;
-  margin-top: 1rem;
-`;
-
-const Header = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1rem; /* 추가: BackBtn과 AlbumCategory 사이에 간격을 추가 */
-  padding-bottom: 0;
-`;
-
-const AlbumCategory = styled.div`
-  font-size: 1.4rem;
-  font-weight: bold;
-  color: black;
-  padding-top: 1rem;
-`;
-
-const BackBtn = styled(Link)`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 0.8rem;
-  font-weight: 700;
-  color: ${color.COLOR_GRAY_TEXT};
-  ${glassEffectStyle()}
-  padding: 0.5rem 1rem;
-  border-radius: 20px;
-  transition: 0.4s;
-  margin-top: 1rem;
-  &:hover {
-    background-color: ${color.COLOR_BLUE_AUTH_BUTTON};
-    color: white;
-  }
-`;
-
-const CardContainer = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 1rem;
-  width: 100%;
-`;

--- a/src/components/pages/RecentReview.tsx
+++ b/src/components/pages/RecentReview.tsx
@@ -17,7 +17,7 @@ const RecentReview = () => {
           </BackBtn>
           <AlbumCategory>최근 평가된 앨범</AlbumCategory>
         </Header>
-        {/* <AlbumCarousel /> */}
+
         <CardContainer>
           {Array.from({ length: 24 }).map((_, index) => (
             <AlbumCard key={index} />

--- a/src/components/pages/RecentReview.tsx
+++ b/src/components/pages/RecentReview.tsx
@@ -3,7 +3,6 @@ import { Link } from "react-router-dom";
 
 import { glassEffectStyle } from "../../styles/style";
 import color from "../../styles/color";
-import { AlbumCard } from "../molecules/album";
 
 import { IoArrowBack } from "react-icons/io5";
 
@@ -19,9 +18,9 @@ const RecentReview = () => {
         </Header>
 
         <CardContainer>
-          {Array.from({ length: 24 }).map((_, index) => (
-            <AlbumCard key={index} />
-          ))}
+          {/* {Array.from({ length: 24 }).map((_, index) => (
+            <AlbumCardItem key={index} />
+          ))} */}
         </CardContainer>
       </Container>
     </>

--- a/src/components/templates/album/AlbumPageTemplate.tsx
+++ b/src/components/templates/album/AlbumPageTemplate.tsx
@@ -1,0 +1,85 @@
+import styled from "styled-components";
+
+import color from "../../../styles/color";
+import { glassEffectStyle } from "../../../styles/style";
+
+import { IoArrowBack } from "react-icons/io5";
+
+import { Link } from "react-router-dom";
+
+import { AlbumType } from "../../../types/albumType";
+import { pathName } from "../../../App";
+import { albumListDummy } from "../../../dummy/album";
+
+import AlbumItem from "../../molecules/album/AlbumItem";
+
+type Props = {
+  category: string;
+  items?: AlbumType[];
+};
+
+const AlbumPageTemplate = ({ category, items = albumListDummy }: Props) => {
+  return (
+    <Container>
+      <Header>
+        <BackBtn to={pathName.album}>
+          <IoArrowBack />
+        </BackBtn>
+        <AlbumCategory>{category}</AlbumCategory>
+      </Header>
+
+      <CardContainer>
+        {items.map((data) => (
+          <AlbumItem key={data.id} data={data} type="card" />
+        ))}
+      </CardContainer>
+    </Container>
+  );
+};
+
+export default AlbumPageTemplate;
+
+const Container = styled.div`
+  ${glassEffectStyle()}
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-radius: 10px;
+  padding: 1.5rem;
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem; /* 추가: BackBtn과 AlbumCategory 사이에 간격을 추가 */
+`;
+
+const AlbumCategory = styled.p`
+  font-size: 1.4rem;
+  font-weight: bold;
+`;
+
+const BackBtn = styled(Link)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1rem;
+  color: ${color.COLOR_GRAY_TEXT};
+  ${glassEffectStyle()}
+  padding: 0.3rem 0.8rem;
+  border-radius: 20px;
+  transition: 0.4s;
+
+  &:hover {
+    background-color: ${color.COLOR_MAIN};
+    color: white;
+  }
+`;
+
+const CardContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+  width: 100%;
+`;

--- a/src/dummy/album.ts
+++ b/src/dummy/album.ts
@@ -1,0 +1,209 @@
+import { AlbumType } from "../types/albumType";
+
+export const albumDummy: AlbumType = {
+  id: "1FVw30SoC91lq1UZ6N9rwN",
+  name: "Supernatural",
+  releasedAt: "2024-06-21 00:00:00",
+  count: 0,
+  averageScore: 0,
+  artists: [
+    {
+      id: "6HvZYsbFfjnjFrWF950C9d",
+      name: "NewJeans",
+    },
+  ],
+  images: [
+    {
+      imageUrl:
+        "https://i.scdn.co/image/ab67616d0000b2737e1eeb0d7cc374a168369c80",
+      width: 640,
+      height: 640,
+    },
+    {
+      imageUrl:
+        "https://i.scdn.co/image/ab67616d00001e027e1eeb0d7cc374a168369c80",
+      width: 300,
+      height: 300,
+    },
+    {
+      imageUrl:
+        "https://i.scdn.co/image/ab67616d000048517e1eeb0d7cc374a168369c80",
+      width: 64,
+      height: 64,
+    },
+  ],
+  modifiedAt: "2024-06-25 11:24:00",
+};
+
+export const albumListDummy: AlbumType[] = [
+  {
+    id: "6XRGc3GNodkhSrPwHnx1KX",
+    name: "NJWMX",
+    releasedAt: "2023-12-19 00:00:00",
+    count: 0,
+    averageScore: 0.0,
+    artists: [
+      {
+        id: "6HvZYsbFfjnjFrWF950C9d",
+        name: "NewJeans",
+      },
+    ],
+    images: [
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d0000b273782a8cae588fee29eefec8b6",
+        width: 640,
+        height: 640,
+      },
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d00001e02782a8cae588fee29eefec8b6",
+        width: 300,
+        height: 300,
+      },
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d00004851782a8cae588fee29eefec8b6",
+        width: 64,
+        height: 64,
+      },
+    ],
+    modifiedAt: "2024-06-25 11:24:00",
+  },
+  {
+    id: "3ZWAsdjkvhG6PuUGIIwpQq",
+    name: "Rebirth In Paradise",
+    releasedAt: "2024-01-17 00:00:00",
+    count: 0,
+    averageScore: 0.0,
+    artists: [
+      {
+        id: "5ApXzDVk6mjD8qZLsBxMjH",
+        name: "NewJeansNim",
+      },
+    ],
+    images: [
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d0000b27390b0c6cebde287aca123f21d",
+        width: 640,
+        height: 640,
+      },
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d00001e0290b0c6cebde287aca123f21d",
+        width: 300,
+        height: 300,
+      },
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d0000485190b0c6cebde287aca123f21d",
+        width: 64,
+        height: 64,
+      },
+    ],
+    modifiedAt: "2024-06-25 11:24:00",
+  },
+  {
+    id: "1FVw30SoC91lq1UZ6N9rwN",
+    name: "Supernatural",
+    releasedAt: "2024-06-21 00:00:00",
+    count: 0,
+    averageScore: 0.0,
+    artists: [
+      {
+        id: "6HvZYsbFfjnjFrWF950C9d",
+        name: "NewJeans",
+      },
+    ],
+    images: [
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d0000b2737e1eeb0d7cc374a168369c80",
+        width: 640,
+        height: 640,
+      },
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d00001e027e1eeb0d7cc374a168369c80",
+        width: 300,
+        height: 300,
+      },
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d000048517e1eeb0d7cc374a168369c80",
+        width: 64,
+        height: 64,
+      },
+    ],
+    modifiedAt: "2024-06-25 11:24:00",
+  },
+  {
+    id: "5pLlVEL5tiXe0QvhaoOhi0",
+    name: "Buddha Handsome",
+    releasedAt: "2023-07-28 00:00:00",
+    count: 0,
+    averageScore: 0.0,
+    artists: [
+      {
+        id: "5ApXzDVk6mjD8qZLsBxMjH",
+        name: "NewJeansNim",
+      },
+    ],
+    images: [
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d0000b27319e1f5b0cbe36c8635ef362a",
+        width: 640,
+        height: 640,
+      },
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d00001e0219e1f5b0cbe36c8635ef362a",
+        width: 300,
+        height: 300,
+      },
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d0000485119e1f5b0cbe36c8635ef362a",
+        width: 64,
+        height: 64,
+      },
+    ],
+    modifiedAt: "2024-06-25 11:24:00",
+  },
+  {
+    id: "0EhZEM4RRz0yioTgucDhJq",
+    name: "How Sweet",
+    releasedAt: "2024-05-24 00:00:00",
+    count: 0,
+    averageScore: 0.0,
+    artists: [
+      {
+        id: "6HvZYsbFfjnjFrWF950C9d",
+        name: "NewJeans",
+      },
+    ],
+    images: [
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d0000b273b657fbb27b17e7bd4691c2b2",
+        width: 640,
+        height: 640,
+      },
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d00001e02b657fbb27b17e7bd4691c2b2",
+        width: 300,
+        height: 300,
+      },
+      {
+        imageUrl:
+          "https://i.scdn.co/image/ab67616d00004851b657fbb27b17e7bd4691c2b2",
+        width: 64,
+        height: 64,
+      },
+    ],
+    modifiedAt: "2024-06-25 11:23:59",
+  },
+];

--- a/src/dummy/albumDetail.ts
+++ b/src/dummy/albumDetail.ts
@@ -1,0 +1,73 @@
+import { AlbumDetailType } from "../types/albumDetailType";
+
+export const albumDetailDummy: AlbumDetailType = {
+  id: "0EhZEM4RRz0yioTgucDhJq",
+  name: "How Sweet",
+  type: "EP",
+  releasedAt: "2024-05-24 00:00:00",
+  trackCount: 4,
+  artists: [
+    {
+      id: "6HvZYsbFfjnjFrWF950C9d",
+      name: "NewJeans",
+    },
+  ],
+  tracks: [
+    {
+      id: "19D8LNpWwIPpi6hs9BG7dq",
+      name: "Bubble Gum",
+      trackNumber: 2,
+      duration: 200266,
+      previewUrl:
+        "https://p.scdn.co/mp3-preview/6209f0f9f4f3432fd0fce127fec7e27bd22f6223?cid=abcfcd8269394fd7af92b59a576f5033",
+      playable: true,
+    },
+    {
+      id: "38tXZcL1gZRfbqfOG0VMTH",
+      name: "How Sweet",
+      trackNumber: 1,
+      duration: 219026,
+      previewUrl:
+        "https://p.scdn.co/mp3-preview/690e6951640ac995e47d19dc13ab44e9de9067f2?cid=abcfcd8269394fd7af92b59a576f5033",
+      playable: true,
+    },
+    {
+      id: "54tBIDmNdxGp04gPNWCCbi",
+      name: "How Sweet (Instrumental)",
+      trackNumber: 3,
+      duration: 219013,
+      previewUrl:
+        "https://p.scdn.co/mp3-preview/79bf6dd5334d98f42c0ada0ce2190aee47be0a8a?cid=abcfcd8269394fd7af92b59a576f5033",
+      playable: true,
+    },
+    {
+      id: "54uNtM77iZ5gawWBQGnEar",
+      name: "Bubble Gum (Instrumental)",
+      trackNumber: 4,
+      duration: 200266,
+      previewUrl:
+        "https://p.scdn.co/mp3-preview/18b7e5097ca6b8737678aedeab37a30fe002f4fe?cid=abcfcd8269394fd7af92b59a576f5033",
+      playable: true,
+    },
+  ],
+  images: [
+    {
+      imageUrl:
+        "https://i.scdn.co/image/ab67616d0000b273b657fbb27b17e7bd4691c2b2",
+      width: 640,
+      height: 640,
+    },
+    {
+      imageUrl:
+        "https://i.scdn.co/image/ab67616d00001e02b657fbb27b17e7bd4691c2b2",
+      width: 300,
+      height: 300,
+    },
+    {
+      imageUrl:
+        "https://i.scdn.co/image/ab67616d00004851b657fbb27b17e7bd4691c2b2",
+      width: 64,
+      height: 64,
+    },
+  ],
+};

--- a/src/dummy/albumReviewStatistic.ts
+++ b/src/dummy/albumReviewStatistic.ts
@@ -1,0 +1,50 @@
+import { AlbumReviewStatisticType } from "../types/albumReviewStatisticType";
+
+export const albumReviewStatisticDummy: AlbumReviewStatisticType = {
+  count: 10,
+  totalScore: 30,
+  averageScore: 3,
+  scoreStatistics: [
+    {
+      score: 1,
+      count: 2,
+      ratio: 20,
+    },
+    {
+      score: 2,
+      count: 2,
+      ratio: 20,
+    },
+    {
+      score: 3,
+      count: 2,
+      ratio: 20,
+    },
+    {
+      score: 4,
+      count: 2,
+      ratio: 20,
+    },
+    {
+      score: 5,
+      count: 2,
+      ratio: 20,
+    },
+  ],
+  genderStatistics: [
+    {
+      gender: "남성",
+      count: 7,
+      totalScore: 21,
+      ratio: 70,
+      averageScore: 3,
+    },
+    {
+      gender: "여성",
+      count: 3,
+      totalScore: 9,
+      ratio: 30,
+      averageScore: 3,
+    },
+  ],
+};

--- a/src/hooks/queries/albumDetail.ts
+++ b/src/hooks/queries/albumDetail.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getAlbumDetail } from "../../api/albumDetail";
+
+export const useAlbumDetailQuery = (albumId: string) => {
+  return useQuery({
+    queryKey: ["albums", albumId],
+    queryFn: () => getAlbumDetail(albumId),
+    enabled: !!albumId,
+  });
+};

--- a/src/hooks/queries/albumDetail.ts
+++ b/src/hooks/queries/albumDetail.ts
@@ -1,11 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { getAlbumDetail } from "../../api/albumDetail";
+import { getAlbumDetail, getAlbumReviewStatistic } from "../../api/albumDetail";
 
 export const useAlbumDetailQuery = (albumId: string) => {
   return useQuery({
-    queryKey: ["albums", albumId],
+    queryKey: ["album", albumId],
     queryFn: () => getAlbumDetail(albumId),
+    enabled: !!albumId,
+  });
+};
+
+export const useAlbumReviewStatisticQuery = (albumId: string) => {
+  return useQuery({
+    queryKey: ["albumReviewStatistic", albumId],
+    queryFn: () => getAlbumReviewStatistic(albumId),
     enabled: !!albumId,
   });
 };

--- a/src/types/albumDetailType.ts
+++ b/src/types/albumDetailType.ts
@@ -1,0 +1,21 @@
+import { AlbumArtistType, AlbumImageType } from "./albumType";
+
+export interface TrackType {
+  id: string;
+  name: string;
+  trackNumber: number;
+  playable: boolean;
+  previewUrl: string;
+  duration: number;
+}
+
+export interface AlbumDetailType {
+  id: string;
+  name: string;
+  type: string;
+  releasedAt: string;
+  trackCount: number;
+  artists: AlbumArtistType[];
+  tracks: TrackType[];
+  images: AlbumImageType[];
+}

--- a/src/types/albumReviewStatisticType.ts
+++ b/src/types/albumReviewStatisticType.ts
@@ -1,0 +1,21 @@
+interface ScoreStatisticType {
+  score: number;
+  count: number;
+  ratio: number;
+}
+
+interface GenderStatisticType {
+  gender: string;
+  count: number;
+  totalScore: number;
+  ratio: number;
+  averageScore: number;
+}
+
+export interface AlbumReviewStatisticType {
+  count: number;
+  totalScore: number;
+  averageScore: number;
+  scoreStatistics: ScoreStatisticType[];
+  genderStatistics: GenderStatisticType[];
+}

--- a/src/types/albumType.ts
+++ b/src/types/albumType.ts
@@ -1,0 +1,21 @@
+type AlbumArtistType = {
+  id: string;
+  name: string;
+};
+
+type AlbumImageType = {
+  imageUrl: string;
+  width: number;
+  height: number;
+};
+
+export type AlbumType = {
+  id: string;
+  name: string;
+  count: number;
+  averageScore: number;
+  modifiedAt: string;
+  releasedAt: string;
+  artists: AlbumArtistType[];
+  images: AlbumImageType[];
+};

--- a/src/types/albumType.ts
+++ b/src/types/albumType.ts
@@ -1,21 +1,21 @@
-type AlbumArtistType = {
+export interface AlbumArtistType {
   id: string;
   name: string;
-};
+}
 
-type AlbumImageType = {
+export interface AlbumImageType {
   imageUrl: string;
   width: number;
   height: number;
-};
+}
 
-export type AlbumType = {
+export interface AlbumType {
   id: string;
   name: string;
   count: number;
   averageScore: number;
-  modifiedAt: string;
+  modifiedAt?: string;
   releasedAt: string;
   artists: AlbumArtistType[];
   images: AlbumImageType[];
-};
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,5 @@
+import dayjs from "dayjs";
+
+export const dateFormat = (date: string) => {
+  return dayjs(date).format("YYYY-MM-DD");
+};

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,16 @@
+// duration 단위: ms
+export const timeFormat = (duration: number) => {
+  const totalSeconds = Math.floor(duration / 1000);
+
+  const hour = Math.floor(totalSeconds / 3600);
+  const min = Math.floor((totalSeconds % 3600) / 60);
+  const sec = totalSeconds % 60;
+
+  let ret = "";
+
+  if (hour > 0) ret += `${hour}시간 `;
+  if (min > 0) ret += `${min}분 `;
+  ret += `${sec}초`;
+
+  return ret;
+};


### PR DESCRIPTION
1. 앨범 페이지에서 각 앨범 목록 api 연동 했음 (각 앨범 목록 페이지의 무한스크롤은 아직)
![image](https://github.com/sing-k/FE/assets/79265861/ebb7eb8e-e3c0-456f-ae97-f3095a3ca5ae)

2. 앨범 데이터 및 카드 아이템 관련 리팩토링
- 기존에는 AlbumCard, AlbumList 두 개로 관리되었는데
- 이제는 AlbumItem 하나로 묶었음! -> 다음에 사용할때 무조건 AlbumItem 으로 쓰세요 type 프롭스로 card 인지 list 인지 넘겨주면 됩니다

3. 앨펌 페이지 리팩토링
- 같은 레이아웃을 사용하는 각 앨범 페이지에서 코드가 중복되는 현상 -> 추후에 유지보수 어려움
- 이거를 하나의 템플릿으로 합쳐서 임포트 시켰음

4. 날짜 포맷을 위한 dayjs 라이브러리 설치
- moment 대신 dayjs 설치했음
- moment 는 크기도 매우 크고 성능도 좋지 않다고 함 -> 얘를 최적화한 것이 dayjs 
- 날짜 관련 파일은 utils/date.ts 에 있습니다용

5. 앨범 상세 페이지 데이터 연동 및 트랙 리스트 미리듣기 모달
![image](https://github.com/sing-k/FE/assets/79265861/b464fac1-9793-4e83-be69-0bf6980ac936)
![image](https://github.com/sing-k/FE/assets/79265861/b3cda0b1-e002-4e28-bcca-80d4779dcaf6)

 