### PR TITLE
앨범 관련 API 연동 및 무한 스크롤 기능 구현 & 약간의 리팩토링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,9 +30,10 @@ export const pathName = {
   signUp: "/signUp",
   login: "/login",
   album: "/album",
-  recentReview: "/album/recentReview",
-  mostReview: "/album/mostReview",
-  highestRated: "/album/highestRated",
+  recentReview: "/album/recent",
+  mostReview: "/album/reviewCount",
+  highestRated: "/album/averageScore",
+  albumDetail: "/album/detail",
   musicRecommendationBoard: "/musicRecommendationBoard",
   board: "/board",
   musicRecommendationPost: "/musicRecommendationBoard/post",
@@ -57,7 +58,10 @@ function App() {
           <Route path={pathName.mostReview} element={<MostReview />} />
           <Route path={pathName.highestRated} element={<HighestRated />} />
 
-          <Route path={`${pathName.album}/:id`} element={<AlbumDetailPage />} />
+          <Route
+            path={`${pathName.albumDetail}/:id`}
+            element={<AlbumDetailPage />}
+          />
 
           <Route
             path={pathName.musicRecommendationBoard}

--- a/src/api/album.ts
+++ b/src/api/album.ts
@@ -19,13 +19,13 @@ const queryData = {
 
 type AlbumType = keyof typeof queryData;
 
-type Args = {
+export type GetAlbumListArgs = {
   cursorId?: string;
   cursorData?: string;
   albumType: AlbumType;
 };
 
-export const getAlbumList = async (args: Args) => {
+export const getAlbumList = async (args: GetAlbumListArgs) => {
   try {
     let url = `/api/albums/list/${queryData[args.albumType].endPoint}?limit=${LIMIT}`;
 

--- a/src/api/album.ts
+++ b/src/api/album.ts
@@ -1,8 +1,17 @@
 import client from "../config/axios";
+import { AlbumType } from "../types/albumType";
+import { QueryFunctionContext } from "@tanstack/react-query";
 
-const LIMIT = 10;
+export const ALBUM_LIST_LIMIT = 10;
 
-const queryData = {
+interface QueryDataType {
+  [key: string]: {
+    endPoint: string;
+    queryName: string;
+  };
+}
+
+const queryData: QueryDataType = {
   recent: {
     endPoint: "recent",
     queryName: "cursor-date",
@@ -17,28 +26,55 @@ const queryData = {
   },
 } as const;
 
-type AlbumType = keyof typeof queryData;
+export type AlbumRequestType = "recent" | "averageScore" | "reviewCount";
+
+export type AlbumPageParam = {
+  cursorId: string;
+  cursorData: string;
+};
 
 export type GetAlbumListArgs = {
   cursorId?: string;
   cursorData?: string;
-  albumType: AlbumType;
+  albumType: AlbumRequestType;
 };
 
-export const getAlbumList = async (args: GetAlbumListArgs) => {
-  try {
-    let url = `/api/albums/list/${queryData[args.albumType].endPoint}?limit=${LIMIT}`;
+// recent: cursor-id 마지막 데이터의 id | cursor-date 마지막 데이터의 modifiedAt
+// averageScore: cursor-id 마지막 데이터의 id | cursor-score 마지막 데이터의 averageScore
+// reviewCount: cursor-id 마지막 데이터의 id | cursor-review-count 마지막 데이터의 count
 
-    if (args.cursorId && args.cursorData) {
-      url += `&cursor-id=${args.cursorId}&${queryData[args.albumType].queryName}=${args.cursorData}`;
+export const getAlbumList = async ({
+  queryKey,
+  pageParam,
+}: QueryFunctionContext): Promise<AlbumType[]> => {
+  if (
+    queryKey.length < 2 ||
+    !queryKey[1] ||
+    typeof queryKey[1] !== "string" ||
+    !Object.keys(queryData).includes(queryKey[1] as string)
+  ) {
+    throw new Error("get album list API error: 잘못된 쿼리 파라미터");
+  }
+
+  const albumType: string = queryKey[1] as string;
+  const endPoint = queryData[albumType].endPoint;
+  const queryName = queryData[albumType].queryName;
+
+  try {
+    let url = `/api/albums/list/${endPoint}?limit=${ALBUM_LIST_LIMIT}`;
+
+    if (pageParam) {
+      const { cursorId, cursorData } = pageParam as AlbumPageParam;
+      // console.log({ cursorId, cursorData });
+      if (cursorId && cursorData) {
+        url += `&cursor-id=${cursorId}&${queryName}=${cursorData}`;
+      }
     }
 
     const res = await client.get(url);
-
-    if (res.status === 200) {
-      return res.data;
-    }
+    // console.log("res: ", res.data);
+    return res.data.data.items as AlbumType[];
   } catch (err) {
-    console.log(`get album ${args.albumType} list error: `, err);
+    throw new Error(`get album ${albumType} list error `);
   }
 };

--- a/src/api/albumDetail.ts
+++ b/src/api/albumDetail.ts
@@ -15,3 +15,25 @@ export const getAlbumReviewStatistic = async (albumId: string) => {
     return res.data.data;
   }
 };
+
+export type AlbumReviewListArgs = {
+  albumId: string;
+  offset?: number;
+  limit?: number;
+  sort?: "NEW" | "LIKES";
+};
+
+export const getAlbumReviewList = async ({
+  albumId,
+  offset = 0,
+  limit = 10,
+  sort = "NEW",
+}: AlbumReviewListArgs) => {
+  const res = await client.get(
+    `/api/reviews/albums/${albumId}?offset=${offset}&limit=${limit}&sort=${sort}`
+  );
+
+  if (res.status === 200) {
+    return res.data.data;
+  }
+};

--- a/src/components/atoms/common/LikeBtn.tsx
+++ b/src/components/atoms/common/LikeBtn.tsx
@@ -29,17 +29,12 @@ const Container = styled.div`
   font-size: 0.9rem;
   padding: 0.4rem 0.8rem;
   border-radius: 5px;
-  border: 1.5px solid ${color.COLOR_LIGHTGRAY_BACKGROUND};
   background-color: ${color.COLOR_LIGHTGRAY_BACKGROUND};
 
   display: flex;
   align-items: center;
   gap: 5px;
-  transition: 0.2s;
 
-  &:hover {
-    border-color: ${color.COLOR_MAIN};
-  }
   &.active {
     border-color: ${color.COLOR_MAIN};
     background-color: ${color.COLOR_MAIN};

--- a/src/components/common/DropDownMenu.tsx
+++ b/src/components/common/DropDownMenu.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+
+import styled from "styled-components";
+import color from "../../styles/color";
+
+type MenuItemType = {
+  text: string;
+  handleClickItem?: () => void;
+};
+
+type Props = {
+  openMenu: boolean;
+  setOpenMenu: React.Dispatch<React.SetStateAction<boolean>>;
+  menuList: MenuItemType[];
+};
+
+const DropDownMenu = ({ openMenu, setOpenMenu, menuList }: Props) => {
+  if (!menuList || menuList.length === 0) return;
+
+  return (
+    <Container>
+      {menuList.map((item) => (
+        <Item key={item.text} onClick={item.handleClickItem}>
+          {item.text}
+        </Item>
+      ))}
+    </Container>
+  );
+};
+
+export default DropDownMenu;
+
+const Container = styled.div`
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 100;
+  width: 120px;
+  padding: 0.5rem;
+  background-color: white;
+  border: 1px solid ${color.COLOR_LIGHTGRAY_BORDER};
+  border-radius: 5px;
+  box-shadow: 5px 5px 10px 0 ${color.COLOR_BOX_SHADOW_COLOR};
+`;
+
+const Item = styled.div`
+  width: 100%;
+  font-size: 0.9rem;
+  color: ${color.COLOR_GRAY_TEXT};
+  font-weight: 600;
+  padding: inherit;
+  cursor: pointer;
+  border-radius: inherit;
+
+  &:hover {
+    background-color: #f0f0f0;
+  }
+`;

--- a/src/components/common/DropDownMenu.tsx
+++ b/src/components/common/DropDownMenu.tsx
@@ -14,7 +14,7 @@ type Props = {
   menuList: MenuItemType[];
 };
 
-const DropDownMenu = ({ openMenu, setOpenMenu, menuList }: Props) => {
+const DropDownMenu = ({ menuList }: Props) => {
   if (!menuList || menuList.length === 0) return;
 
   return (

--- a/src/components/common/ErrorMessage.tsx
+++ b/src/components/common/ErrorMessage.tsx
@@ -1,0 +1,57 @@
+import styled from "styled-components";
+import color from "../../styles/color";
+import { glassEffectStyle } from "../../styles/style";
+
+import { BiSolidMessageRoundedError } from "react-icons/bi";
+
+type Props = {
+  message?: string;
+};
+
+const ErrorMessage = ({ message }: Props) => {
+  return (
+    <Container>
+      <Wrapper>
+        <ErrorIcon />
+
+        <Text>시스템 오류</Text>
+      </Wrapper>
+
+      {message && <Message>{message}</Message>}
+    </Container>
+  );
+};
+
+export default ErrorMessage;
+
+const Container = styled.div`
+  ${glassEffectStyle()}
+  width: 100%;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  border-radius: 5px;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+const ErrorIcon = styled(BiSolidMessageRoundedError)`
+  font-size: 2rem;
+  color: ${color.COLOR_MAIN};
+`;
+
+const Text = styled.p`
+  font-weight: bold;
+  font-size: 1.2rem;
+`;
+
+const Message = styled.p`
+  color: ${color.COLOR_GRAY_TEXT};
+`;

--- a/src/components/common/Loading.tsx
+++ b/src/components/common/Loading.tsx
@@ -1,0 +1,40 @@
+import styled, { keyframes } from "styled-components";
+import color from "../../styles/color";
+
+const Loading = () => {
+  return (
+    <Container>
+      <Spinner />
+    </Container>
+  );
+};
+
+export default Loading;
+
+const Container = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+`;
+
+const spin = keyframes`
+from {
+    transform: rotate(0deg);
+}
+to {
+    transform: rotate(360deg);
+}
+`;
+
+const Spinner = styled.div`
+  width: 50px;
+  aspect-ratio: 1 /1;
+  box-size: border-box;
+  border: 5px solid ${color.COLOR_TRANSPARENT_WHITE};
+  border-radius: 50%;
+  border-top-color: ${color.COLOR_MAIN};
+
+  animation: ${spin} 1s ease-in-out infinite;
+`;

--- a/src/components/molecules/album/AlbumItem.tsx
+++ b/src/components/molecules/album/AlbumItem.tsx
@@ -36,7 +36,11 @@ const AlbumItem = ({
   };
 
   return (
-    <Container ref={itemRef} style={{ width }} onClick={goAlbumDetailPage}>
+    <Container
+      ref={itemRef}
+      style={{ width, maxWidth: width }}
+      onClick={goAlbumDetailPage}
+    >
       {type === "card" ? (
         <AlbumCardItem data={data} />
       ) : type === "list" ? (

--- a/src/components/molecules/album/AlbumItem.tsx
+++ b/src/components/molecules/album/AlbumItem.tsx
@@ -32,7 +32,7 @@ const AlbumItem = ({
   const navigate = useNavigate();
 
   const goAlbumDetailPage = () => {
-    navigate(`${pathName.album}/${data.id}`);
+    navigate(`${pathName.albumDetail}/${data.id}`);
   };
 
   return (

--- a/src/components/molecules/albumDetail/AlbumGenderPercentage.tsx
+++ b/src/components/molecules/albumDetail/AlbumGenderPercentage.tsx
@@ -45,7 +45,7 @@ const AlbumGenderPercentage = ({ data }: Props) => {
               {
                 label: "# of Percentages",
                 data: genderStatistics.map((el) => el.ratio),
-                backgroundColor: [color.COLOR_FEMALE, color.COLOR_MALE],
+                backgroundColor: [color.COLOR_MALE, color.COLOR_FEMALE],
                 borderColor: ["#ffffff", "#ffffff"],
                 borderWidth: 1,
               },

--- a/src/components/molecules/albumDetail/AlbumReview.tsx
+++ b/src/components/molecules/albumDetail/AlbumReview.tsx
@@ -7,41 +7,45 @@ import color from "../../../styles/color";
 
 import { FaUser, FaRegThumbsDown, FaRegThumbsUp } from "react-icons/fa";
 
+import { AlbumReviewType } from "../../../types/albumReviewType";
+
+import { dateTimeFormat } from "../../../utils/date";
+
 import StarRating from "../../atoms/albumDetail/StarRating";
 
-const AlbumReview = () => {
+type Props = {
+  data: AlbumReviewType;
+};
+
+const AlbumReview = ({ data }: Props) => {
   return (
     <Container>
       <Wrapper>
         <StarRatingDiv>
-          <StarRating rating={4.5} />
-          4.5
+          <StarRating rating={data.score} />
+          {data.score}
         </StarRatingDiv>
-        2024-06-01
+        {dateTimeFormat(data.createdAt)}
       </Wrapper>
 
-      <ReviewText>
-        이 앨범은
-        킹갓제너럴엠페러마제스티골져스프레셔스뷰리풀하이클래스엘레강스럭셔리클래식지니어스원더풀러블리월드탑클래스
-        입니다. 감사합니다
-      </ReviewText>
+      <ReviewText>{data.content}</ReviewText>
 
       <Wrapper>
         <WriterDiv>
           <WriterImgDiv>
             <FaUser color={"white"} />
           </WriterImgDiv>
-          민숭이
+          {data.reviewer.nickname ? data.reviewer.nickname : "닉네임없음"}
         </WriterDiv>
 
         <BtnDiv>
           <Btn>
             <FaRegThumbsUp />
-            123
+            {data.pros}
           </Btn>
           <Btn>
             <FaRegThumbsDown />
-            43
+            {data.cons}
           </Btn>
         </BtnDiv>
       </Wrapper>

--- a/src/components/molecules/albumDetail/AlbumTrack.tsx
+++ b/src/components/molecules/albumDetail/AlbumTrack.tsx
@@ -26,7 +26,7 @@ const AlbumTrack = ({ track }: Props) => {
   return (
     <>
       <Container>
-        <Wrapper>
+        <Wrapper style={{ flex: 1 }}>
           <Number>{track.trackNumber}</Number>
           <TrackName>{track.name}</TrackName>
           <Artist>{track.artists[0].name}</Artist>
@@ -60,6 +60,7 @@ const Container = styled.div`
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem 0.8rem;
+  gap: 1rem;
 `;
 
 const Wrapper = styled.div`
@@ -75,11 +76,14 @@ const Number = styled.p`
 
 const TrackName = styled.p`
   font-weight: bold;
+  font-size: 1rem;
+  line-height: 1.5rem;
 `;
 
 const Artist = styled.p`
   color: ${color.COLOR_GRAY_TEXT};
   font-size: 0.9rem;
+  font-weight: bold;
 `;
 
 const Time = styled.p`

--- a/src/components/molecules/albumDetail/AlbumTrack.tsx
+++ b/src/components/molecules/albumDetail/AlbumTrack.tsx
@@ -29,7 +29,7 @@ const AlbumTrack = ({ track }: Props) => {
         <Wrapper>
           <Number>{track.trackNumber}</Number>
           <TrackName>{track.name}</TrackName>
-          <Artist>아티스트 이름</Artist>
+          <Artist>{track.artists[0].name}</Artist>
         </Wrapper>
 
         <Wrapper>

--- a/src/components/molecules/board/PostMenu.tsx
+++ b/src/components/molecules/board/PostMenu.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+
+import styled from "styled-components";
+import color from "../../../styles/color";
+
+import { FaCog } from "react-icons/fa";
+
+import DropDownMenu from "../../common/DropDownMenu";
+
+const PostMenu = () => {
+  const [openMenu, setOpenMenu] = useState<boolean>(false);
+
+  const onClick = () => {
+    setOpenMenu(!openMenu);
+  };
+
+  const handleClickUpdate = () => {
+    setOpenMenu(false);
+  };
+
+  const handleClickDelete = () => {
+    const result = window.confirm("게시글을 삭제하시겠습니까?");
+
+    if (result) {
+      // 삭제 로직
+    }
+
+    setOpenMenu(false);
+  };
+
+  return (
+    <Container>
+      <EditBtn onClick={onClick} />
+
+      {openMenu && (
+        <DropDownMenu
+          openMenu={openMenu}
+          setOpenMenu={setOpenMenu}
+          menuList={[
+            {
+              text: "수정",
+              handleClickItem: handleClickUpdate,
+            },
+            {
+              text: "삭제",
+              handleClickItem: handleClickDelete,
+            },
+          ]}
+        />
+      )}
+    </Container>
+  );
+};
+
+export default PostMenu;
+
+const Container = styled.div`
+  position: relative;
+`;
+
+const EditBtn = styled(FaCog)`
+  cursor: pointer;
+  color: ${color.COLOR_GRAY_TEXT};
+`;

--- a/src/components/molecules/comment/CommentMenu.tsx
+++ b/src/components/molecules/comment/CommentMenu.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+
+import styled from "styled-components";
+import color from "../../../styles/color";
+
+import { BsThreeDotsVertical } from "react-icons/bs";
+
+import DropDownMenu from "../../common/DropDownMenu";
+
+const CommentMenu = () => {
+  const [openMenu, setOpenMenu] = useState<boolean>(false);
+
+  const onClick = () => {
+    setOpenMenu(!openMenu);
+  };
+
+  const handleClickUpdate = () => {
+    setOpenMenu(false);
+  };
+
+  const handleClickDelete = () => {
+    const result = window.confirm("댓글을 삭제하시겠습니까?");
+
+    if (result) {
+      // 삭제 로직
+    }
+
+    setOpenMenu(false);
+  };
+
+  return (
+    <Container>
+      <Dots onClick={onClick} />
+
+      {openMenu && (
+        <DropDownMenu
+          openMenu={openMenu}
+          setOpenMenu={setOpenMenu}
+          menuList={[
+            {
+              text: "수정",
+              handleClickItem: handleClickUpdate,
+            },
+            {
+              text: "삭제",
+              handleClickItem: handleClickDelete,
+            },
+          ]}
+        />
+      )}
+    </Container>
+  );
+};
+
+export default CommentMenu;
+
+const Container = styled.div`
+  position: relative;
+`;
+
+const Dots = styled(BsThreeDotsVertical)`
+  cursor: pointer;
+  color: ${color.COLOR_GRAY_TEXT};
+`;

--- a/src/components/molecules/comment/PostComment.tsx
+++ b/src/components/molecules/comment/PostComment.tsx
@@ -2,11 +2,11 @@ import styled from "styled-components";
 
 import color from "../../../styles/color";
 
-import { BsThreeDotsVertical } from "react-icons/bs";
 import { MdOutlineSubdirectoryArrowRight } from "react-icons/md";
 
 import UserInfo from "../../common/UserInfo";
 import LikeBtn from "../../atoms/common/LikeBtn";
+import CommentMenu from "./CommentMenu";
 
 interface WriterType {
   id: string;
@@ -44,7 +44,7 @@ const Comment = (data: CommentType) => {
           {data.createdAt}
         </UserWrapper>
 
-        <Dots />
+        <CommentMenu />
       </Wrapper>
 
       <Wrapper style={{ alignItems: "flex-start" }}>
@@ -120,11 +120,6 @@ const UserWrapper = styled.div`
   color: ${color.COLOR_GRAY_TEXT};
   font-size: 0.8rem;
   gap: 10px;
-`;
-
-const Dots = styled(BsThreeDotsVertical)`
-  cursor: pointer;
-  color: ${color.COLOR_GRAY_TEXT};
 `;
 
 const ContentsWrapper = styled.div`

--- a/src/components/molecules/navbar/NavMenuList.tsx
+++ b/src/components/molecules/navbar/NavMenuList.tsx
@@ -13,9 +13,8 @@ const NavMenuList = () => {
   const location = useLocation();
 
   useEffect(() => {
-    let [_, path, ...rest] = location.pathname.split("/");
+    let path = location.pathname.split("/")[1];
     setCurrentTab(`/${path}`);
-    // console.log(rest); //배포 에러 때문에 추가 추후에 삭제 바람
   }, [location]);
 
   return (

--- a/src/components/organisms/album/AlbumCarousel.tsx
+++ b/src/components/organisms/album/AlbumCarousel.tsx
@@ -22,6 +22,7 @@ const GAP_REM = 1;
 const AlbumCarousel = ({ items = albumListDummy }: Props) => {
   const [itemWidth, setItemWidth] = useState<number>(0);
   const [currentIdx, setCurrentIdx] = useState<number>(0);
+  const [viewIndicator, setViewIndicator] = useState<boolean>(true);
 
   const itemRef = useRef<HTMLDivElement>(null);
   const carouselRef = useRef<HTMLDivElement>(null);
@@ -39,9 +40,20 @@ const AlbumCarousel = ({ items = albumListDummy }: Props) => {
   };
 
   const handleResize = () => {
-    if (itemRef.current === null) return;
+    if (itemRef.current === null || carouselRef.current === null) return;
 
-    setItemWidth(itemRef.current.offsetWidth);
+    const itemWidth = itemRef.current.offsetWidth;
+    const carouselWidth = carouselRef.current.offsetWidth;
+    const gapWidth =
+      GAP_REM * (isPc ? 16 : isTablet ? 14 : 12) * (items.length - 1);
+
+    if (carouselWidth >= itemWidth * items.length + gapWidth) {
+      setViewIndicator(false);
+    } else {
+      setViewIndicator(true);
+    }
+
+    setItemWidth(itemWidth);
   };
 
   useEffect(() => {
@@ -81,26 +93,28 @@ const AlbumCarousel = ({ items = albumListDummy }: Props) => {
         ))}
       </Carousel>
 
-      <IndicatorWrapper>
-        <IndicatorBtn onClick={handleClickPrev}>
-          <FaChevronCircleLeft />
-        </IndicatorBtn>
+      {viewIndicator && (
+        <IndicatorWrapper>
+          <IndicatorBtn onClick={handleClickPrev}>
+            <FaChevronCircleLeft />
+          </IndicatorBtn>
 
-        <div style={{ overflow: "hidden" }}>
-          <Indicator ref={indicatorRef}>
-            {items.map((_, idx) => (
-              <Dot
-                key={`${idx}indicator`}
-                className={idx === currentIdx ? "focused" : "none"}
-              />
-            ))}
-          </Indicator>
-        </div>
+          <div style={{ overflow: "hidden" }}>
+            <Indicator ref={indicatorRef}>
+              {items.map((_, idx) => (
+                <Dot
+                  key={`${idx}indicator`}
+                  className={idx === currentIdx ? "focused" : "none"}
+                />
+              ))}
+            </Indicator>
+          </div>
 
-        <IndicatorBtn onClick={handleClickNext}>
-          <FaChevronCircleRight />
-        </IndicatorBtn>
-      </IndicatorWrapper>
+          <IndicatorBtn onClick={handleClickNext}>
+            <FaChevronCircleRight />
+          </IndicatorBtn>
+        </IndicatorWrapper>
+      )}
     </Container>
   );
 };

--- a/src/components/organisms/album/AlbumSection.tsx
+++ b/src/components/organisms/album/AlbumSection.tsx
@@ -7,7 +7,7 @@ import AlbumCarousel from "./AlbumCarousel";
 import { glassEffectStyle } from "../../../styles/style";
 import color from "../../../styles/color";
 
-import { GetAlbumListArgs } from "../../../api/album";
+import { AlbumRequestType } from "../../../api/album";
 
 import { useAlbumListQuery } from "../../../hooks/queries/album";
 
@@ -17,14 +17,15 @@ import ErrorMessage from "../../common/ErrorMessage";
 type AlbumSectionType = {
   title: string;
   link: string;
-  args: GetAlbumListArgs;
+  albumType: AlbumRequestType;
 };
 
-const AlbumSection = ({ title, link, args }: AlbumSectionType) => {
-  const { data, isLoading, isError, error } = useAlbumListQuery(args);
+const AlbumSection = ({ title, link, albumType }: AlbumSectionType) => {
+  const { data, isLoading, isError, error } = useAlbumListQuery(albumType);
 
   if (isLoading) return <Loading />;
   if (isError) return <ErrorMessage message={error.message} />;
+  if (!data) return;
 
   return (
     <Container>
@@ -33,7 +34,7 @@ const AlbumSection = ({ title, link, args }: AlbumSectionType) => {
         <MoreBtn to={link}>더보기</MoreBtn>
       </Header>
 
-      <AlbumCarousel items={data.data.items} />
+      <AlbumCarousel items={data} />
     </Container>
   );
 };

--- a/src/components/organisms/album/AlbumSection.tsx
+++ b/src/components/organisms/album/AlbumSection.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from "react";
-
 import styled from "styled-components";
 
 import { Link } from "react-router-dom";
@@ -9,25 +7,24 @@ import AlbumCarousel from "./AlbumCarousel";
 import { glassEffectStyle } from "../../../styles/style";
 import color from "../../../styles/color";
 
-import { AlbumType } from "../../../types/albumType";
+import { GetAlbumListArgs } from "../../../api/album";
+
+import { useAlbumListQuery } from "../../../hooks/queries/album";
+
+import Loading from "../../common/Loading";
+import ErrorMessage from "../../common/ErrorMessage";
 
 type AlbumSectionType = {
   title: string;
   link: string;
-  fetchData: () => any;
+  args: GetAlbumListArgs;
 };
 
-const AlbumSection = ({ title, link, fetchData }: AlbumSectionType) => {
-  const [items, setItems] = useState<AlbumType[]>();
+const AlbumSection = ({ title, link, args }: AlbumSectionType) => {
+  const { data, isLoading, isError, error } = useAlbumListQuery(args);
 
-  useEffect(() => {
-    fetchData().then((res: any) => {
-      // console.log(res.data.items);
-      setItems(res.data.items as AlbumType[]);
-    });
-  }, [fetchData]);
-
-  if (!items) return;
+  if (isLoading) return <Loading />;
+  if (isError) return <ErrorMessage message={error.message} />;
 
   return (
     <Container>
@@ -36,7 +33,7 @@ const AlbumSection = ({ title, link, fetchData }: AlbumSectionType) => {
         <MoreBtn to={link}>더보기</MoreBtn>
       </Header>
 
-      <AlbumCarousel items={items} />
+      <AlbumCarousel items={data.data.items} />
     </Container>
   );
 };

--- a/src/components/organisms/albumDetail/AlbumDetailCard.tsx
+++ b/src/components/organisms/albumDetail/AlbumDetailCard.tsx
@@ -14,7 +14,7 @@ type Props = {
 };
 
 const AlbumDetailCard = ({ data }: Props) => {
-  const { images, type, name, artists, releasedAt } = data;
+  const { images, type, name, artists, releasedAt, count, averageScore } = data;
 
   const { isMobile } = useMediaQueries();
 
@@ -39,8 +39,8 @@ const AlbumDetailCard = ({ data }: Props) => {
         artist={artists[0].name}
         releaseDate={releasedAt}
         genre={"일렉트로닉"}
-        rating={3}
-        reviewCount={10}
+        rating={averageScore}
+        reviewCount={count}
       />
 
       <BadgeImage src={Badge} />

--- a/src/components/organisms/albumDetail/AlbumDetailInfo.tsx
+++ b/src/components/organisms/albumDetail/AlbumDetailInfo.tsx
@@ -6,6 +6,8 @@ import { useAlbumDetailQuery } from "../../../hooks/queries/albumDetail";
 
 import AlbumDetailCard from "./AlbumDetailCard";
 import AlbumTrackList from "./AlbumTrackList";
+import Loading from "../../common/Loading";
+import ErrorMessage from "../../common/ErrorMessage";
 
 type Props = {
   albumId: string;
@@ -14,8 +16,8 @@ type Props = {
 const AlbumDetailInfo = ({ albumId }: Props) => {
   const { data, isLoading, isError, error } = useAlbumDetailQuery(albumId);
 
-  if (isLoading) return <>로딩중 {"><"}</>;
-  if (isError) return <>미친 에러 {error.message}</>;
+  if (isLoading) return <Loading />;
+  if (isError) return <ErrorMessage message={error.message} />;
 
   return (
     <Container>

--- a/src/components/organisms/albumDetail/AlbumDetailReview.tsx
+++ b/src/components/organisms/albumDetail/AlbumDetailReview.tsx
@@ -17,7 +17,7 @@ const AlbumDetailReview = ({ albumId }: Props) => {
 
       <AlbumReviewInput />
 
-      <AlbumReviewList />
+      <AlbumReviewList albumId={albumId} />
     </Container>
   );
 };

--- a/src/components/organisms/albumDetail/AlbumReviewDashboard.tsx
+++ b/src/components/organisms/albumDetail/AlbumReviewDashboard.tsx
@@ -7,6 +7,8 @@ import { useAlbumReviewStatisticQuery } from "../../../hooks/queries/albumDetail
 import AlbumReviewRating from "../../molecules/albumDetail/AlbumReviewRating";
 import AlbumScorePercentage from "../../molecules/albumDetail/AlbumScorePercentage";
 import AlbumGenderPercentage from "../../molecules/albumDetail/AlbumGenderPercentage";
+import Loading from "../../common/Loading";
+import ErrorMessage from "../../common/ErrorMessage";
 
 type Props = {
   albumId: string;
@@ -16,8 +18,8 @@ const AlbumReviewDashboard = ({ albumId }: Props) => {
   const { data, isLoading, isError, error } =
     useAlbumReviewStatisticQuery(albumId);
 
-  if (isLoading) return <>로딩중 {"><"}</>;
-  if (isError) return <>미친 에러 {error.message}</>;
+  if (isLoading) return <Loading />;
+  if (isError) return <ErrorMessage message={error.message} />;
 
   return (
     <Container>

--- a/src/components/organisms/albumDetail/AlbumReviewInput.tsx
+++ b/src/components/organisms/albumDetail/AlbumReviewInput.tsx
@@ -22,6 +22,7 @@ const AlbumReviewInput = () => {
         setInput={setInput}
         button={{
           text: "등록",
+          onClickButton: () => {},
         }}
         placeholder="감상평을 작성해 주세요!"
         textarea={true}

--- a/src/components/organisms/albumDetail/AlbumReviewList.tsx
+++ b/src/components/organisms/albumDetail/AlbumReviewList.tsx
@@ -4,10 +4,15 @@ import styled from "styled-components";
 
 import { useLocation, useNavigate } from "react-router-dom";
 
+import color from "../../../styles/color";
 import { glassEffectStyle } from "../../../styles/style";
+
+import { useAlbumReviewListQuery } from "../../../hooks/queries/albumDetail";
 
 import AlbumReview from "../../molecules/albumDetail/AlbumReview";
 import TabMenu from "../../common/TabMenu";
+
+import { AlbumReviewType } from "../../../types/albumReviewType";
 
 const filterObj = {
   recent: "최신순",
@@ -16,11 +21,22 @@ const filterObj = {
 
 type FilterKey = keyof typeof filterObj;
 
-const AlbumReviewList = () => {
+type Props = {
+  albumId: string;
+};
+
+const AlbumReviewList = ({ albumId }: Props) => {
   const location = useLocation();
   const navigate = useNavigate();
 
   const [currentFilter, setCurrentFilter] = useState<FilterKey | "">("");
+
+  const { data, isLoading, isError, error } = useAlbumReviewListQuery({
+    albumId,
+    offset: 0,
+    limit: 10,
+    sort: currentFilter === "recent" ? "NEW" : "LIKES",
+  });
 
   const onClickTab = (key?: string) => {
     const path =
@@ -41,6 +57,8 @@ const AlbumReviewList = () => {
   }, [location]);
 
   if (currentFilter === "") return;
+  if (isLoading) return <>Loading....</>;
+  if (isError) return <>Error... {error.message}</>;
 
   return (
     <div style={{ borderRadius: "inherit" }}>
@@ -51,9 +69,15 @@ const AlbumReviewList = () => {
       />
 
       <Container>
-        {[...Array(10)].map((_, idx) => (
-          <AlbumReview key={`review${idx}`} />
-        ))}
+        {data && data?.items.length === 0 ? (
+          <EmptyText>등록된 감상평이 없습니다.</EmptyText>
+        ) : (
+          <>
+            {data?.items.map((data: AlbumReviewType) => (
+              <AlbumReview key={`review${data.id}`} data={data} />
+            ))}
+          </>
+        )}
       </Container>
     </div>
   );
@@ -69,4 +93,11 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+`;
+
+const EmptyText = styled.div`
+  color: ${color.COLOR_GRAY_TEXT};
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 2rem 0;
 `;

--- a/src/components/organisms/albumDetail/AlbumReviewList.tsx
+++ b/src/components/organisms/albumDetail/AlbumReviewList.tsx
@@ -9,10 +9,12 @@ import { glassEffectStyle } from "../../../styles/style";
 
 import { useAlbumReviewListQuery } from "../../../hooks/queries/albumDetail";
 
+import { AlbumReviewType } from "../../../types/albumReviewType";
+
 import AlbumReview from "../../molecules/albumDetail/AlbumReview";
 import TabMenu from "../../common/TabMenu";
-
-import { AlbumReviewType } from "../../../types/albumReviewType";
+import Loading from "../../common/Loading";
+import ErrorMessage from "../../common/ErrorMessage";
 
 const filterObj = {
   recent: "최신순",
@@ -57,8 +59,8 @@ const AlbumReviewList = ({ albumId }: Props) => {
   }, [location]);
 
   if (currentFilter === "") return;
-  if (isLoading) return <>Loading....</>;
-  if (isError) return <>Error... {error.message}</>;
+  if (isLoading) return <Loading />;
+  if (isError) return <ErrorMessage message={error.message} />;
 
   return (
     <div style={{ borderRadius: "inherit" }}>

--- a/src/components/organisms/board/PostInfo.tsx
+++ b/src/components/organisms/board/PostInfo.tsx
@@ -2,10 +2,9 @@ import styled from "styled-components";
 
 import color from "../../../styles/color";
 
-import { FaCog } from "react-icons/fa";
-
 import UserInfo from "../../common/UserInfo";
 import { PostCommentNum, PostLikeNum } from "../../atoms";
+import PostMenu from "../../molecules/board/PostMenu";
 
 const PostInfo = () => {
   return (
@@ -15,7 +14,7 @@ const PostInfo = () => {
       <TitleWrapper>
         <Title>게시글 제목 부분</Title>
 
-        <EditBtn />
+        <PostMenu />
       </TitleWrapper>
 
       <InfoWrapper>
@@ -48,11 +47,6 @@ const TitleWrapper = styled.div`
 const Title = styled.div`
   font-size: 1.6rem;
   font-weight: bold;
-`;
-
-const EditBtn = styled(FaCog)`
-  cursor: pointer;
-  color: ${color.COLOR_GRAY_TEXT};
 `;
 
 const InfoWrapper = styled.div`

--- a/src/components/pages/AlbumDetailPage.tsx
+++ b/src/components/pages/AlbumDetailPage.tsx
@@ -24,7 +24,7 @@ const AlbumDetailPage = () => {
 
   const onClickTab = (key?: string) => {
     const path = key === "review" ? "?tab=review" : "";
-    navigate(`${pathName.album}/${id}${path}`);
+    navigate(`${pathName.albumDetail}/${id}${path}`);
   };
 
   useEffect(() => {

--- a/src/components/pages/AlbumPage.tsx
+++ b/src/components/pages/AlbumPage.tsx
@@ -7,9 +7,8 @@ import { AlbumSearchList } from "../organisms/album";
 
 import AlbumSection from "../organisms/album/AlbumSection";
 
-import { pathName } from "../../App";
-
 import { AlbumType } from "../../types/albumType";
+import { pathName } from "../../App";
 
 const AlbumPage = () => {
   //   const { isPc } = useMediaQueries();
@@ -55,17 +54,17 @@ const AlbumPage = () => {
       <AlbumSection
         title="최근 평가된 앨범"
         link={pathName.recentReview}
-        args={{ albumType: "recent" }}
+        albumType="recent"
       />
       <AlbumSection
         title="평가 많은 순"
         link={pathName.mostReview}
-        args={{ albumType: "reviewCount" }}
+        albumType="reviewCount"
       />
       <AlbumSection
         title="평점 높은 순"
         link={pathName.highestRated}
-        args={{ albumType: "averageScore" }}
+        albumType="averageScore"
       />
     </>
   );

--- a/src/components/pages/AlbumPage.tsx
+++ b/src/components/pages/AlbumPage.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
 import { useApi } from "../../hooks";
-import { getAlbumList } from "../../api/album";
 
 import { AlbumSearchList } from "../organisms/album";
 
@@ -56,17 +55,17 @@ const AlbumPage = () => {
       <AlbumSection
         title="최근 평가된 앨범"
         link={pathName.recentReview}
-        fetchData={getAlbumList.bind(this, { albumType: "recent" })}
+        args={{ albumType: "recent" }}
       />
       <AlbumSection
         title="평가 많은 순"
         link={pathName.mostReview}
-        fetchData={getAlbumList.bind(this, { albumType: "reviewCount" })}
+        args={{ albumType: "reviewCount" }}
       />
       <AlbumSection
         title="평점 높은 순"
         link={pathName.highestRated}
-        fetchData={getAlbumList.bind(this, { albumType: "averageScore" })}
+        args={{ albumType: "averageScore" }}
       />
     </>
   );

--- a/src/components/pages/HighestRated.tsx
+++ b/src/components/pages/HighestRated.tsx
@@ -3,7 +3,10 @@ import AlbumPageTemplate from "../templates/album/AlbumPageTemplate";
 const HighestRated = () => {
   return (
     <>
-      <AlbumPageTemplate category="평점 높은 순"></AlbumPageTemplate>
+      <AlbumPageTemplate
+        category="평점 높은 순"
+        albumType="averageScore"
+      ></AlbumPageTemplate>
     </>
   );
 };

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -1,20 +1,39 @@
 import styled from "styled-components";
 
-import { HomePostList } from "../organisms";
-import { AlbumCarousel } from "../organisms/album";
-
-import { useMediaQueries } from "../../hooks";
+import { glassEffectStyle } from "../../styles/style";
+import color from "../../styles/color";
 
 import { Outlet } from "react-router-dom";
 
-import { albumListDummy } from "../../dummy/album";
+import { FaStar, FaMusic } from "react-icons/fa";
+
+import { useMediaQueries } from "../../hooks";
+import { useAlbumListQuery } from "../../hooks/queries/album";
+
+import { HomePostList } from "../organisms";
+import { AlbumCarousel } from "../organisms/album";
+import Loading from "../common/Loading";
+import ErrorMessage from "../common/ErrorMessage";
 
 const MainPage = () => {
   const { isPc } = useMediaQueries();
+  const { data, isLoading, isError, error } = useAlbumListQuery("averageScore");
+
+  if (isLoading) return <Loading />;
+  if (isError) return <ErrorMessage message={error.message} />;
+  if (!data) return;
 
   return (
     <>
-      <AlbumCarousel items={albumListDummy} />
+      <AlbumContainer>
+        <TextWrapper>
+          <FaMusic />
+          <Text>평점 높은 앨범</Text>
+          <FaStar />
+        </TextWrapper>
+
+        <AlbumCarousel items={data} />
+      </AlbumContainer>
 
       <PostListWrapper style={isPc ? { flexDirection: "row" } : {}}>
         <HomePostList text="음악 추천 게시판" />
@@ -35,4 +54,28 @@ const PostListWrapper = styled.div`
   flex-direction: column;
   justify-content: space-between;
   gap: 3rem;
+`;
+
+const AlbumContainer = styled.div`
+  ${glassEffectStyle()}
+  width: 100%;
+  padding: 1rem 1.5rem;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1rem;
+`;
+
+const TextWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  color: ${color.COLOR_MAIN};
+  font-size: 1.2rem;
+  gap: 0.5rem;
+`;
+
+const Text = styled.p`
+  font-weight: bold;
+  color: black;
 `;

--- a/src/components/pages/MostReview.tsx
+++ b/src/components/pages/MostReview.tsx
@@ -3,7 +3,10 @@ import AlbumPageTemplate from "../templates/album/AlbumPageTemplate";
 const MostReview = () => {
   return (
     <>
-      <AlbumPageTemplate category="평가 많은 순"></AlbumPageTemplate>
+      <AlbumPageTemplate
+        category="평가 많은 순"
+        albumType="reviewCount"
+      ></AlbumPageTemplate>
     </>
   );
 };

--- a/src/components/pages/RecentReview.tsx
+++ b/src/components/pages/RecentReview.tsx
@@ -3,7 +3,10 @@ import AlbumPageTemplate from "../templates/album/AlbumPageTemplate";
 const RecentReview = () => {
   return (
     <>
-      <AlbumPageTemplate category="최근 평가된 앨범"></AlbumPageTemplate>
+      <AlbumPageTemplate
+        category="최근 평가된 앨범"
+        albumType="recent"
+      ></AlbumPageTemplate>
     </>
   );
 };

--- a/src/components/templates/album/AlbumPageTemplate.tsx
+++ b/src/components/templates/album/AlbumPageTemplate.tsx
@@ -82,9 +82,9 @@ const AlbumPageTemplate = ({ category, albumType }: Props) => {
             ))}
           </React.Fragment>
         ))}
-
-        {isFetchingNextPage && <Loading />}
       </CardContainer>
+
+      {isFetchingNextPage && <Loading />}
     </Container>
   );
 };

--- a/src/dummy/albumDetail.ts
+++ b/src/dummy/albumDetail.ts
@@ -6,6 +6,8 @@ export const albumDetailDummy: AlbumDetailType = {
   type: "EP",
   releasedAt: "2024-05-24 00:00:00",
   trackCount: 4,
+  count: 0,
+  averageScore: 0.0,
   artists: [
     {
       id: "6HvZYsbFfjnjFrWF950C9d",
@@ -14,21 +16,33 @@ export const albumDetailDummy: AlbumDetailType = {
   ],
   tracks: [
     {
-      id: "19D8LNpWwIPpi6hs9BG7dq",
-      name: "Bubble Gum",
-      trackNumber: 2,
-      duration: 200266,
-      previewUrl:
-        "https://p.scdn.co/mp3-preview/6209f0f9f4f3432fd0fce127fec7e27bd22f6223?cid=abcfcd8269394fd7af92b59a576f5033",
-      playable: true,
-    },
-    {
       id: "38tXZcL1gZRfbqfOG0VMTH",
       name: "How Sweet",
       trackNumber: 1,
       duration: 219026,
       previewUrl:
         "https://p.scdn.co/mp3-preview/690e6951640ac995e47d19dc13ab44e9de9067f2?cid=abcfcd8269394fd7af92b59a576f5033",
+      artists: [
+        {
+          id: "6HvZYsbFfjnjFrWF950C9d",
+          name: "NewJeans",
+        },
+      ],
+      playable: true,
+    },
+    {
+      id: "19D8LNpWwIPpi6hs9BG7dq",
+      name: "Bubble Gum",
+      trackNumber: 2,
+      duration: 200266,
+      previewUrl:
+        "https://p.scdn.co/mp3-preview/6209f0f9f4f3432fd0fce127fec7e27bd22f6223?cid=abcfcd8269394fd7af92b59a576f5033",
+      artists: [
+        {
+          id: "6HvZYsbFfjnjFrWF950C9d",
+          name: "NewJeans",
+        },
+      ],
       playable: true,
     },
     {
@@ -38,6 +52,12 @@ export const albumDetailDummy: AlbumDetailType = {
       duration: 219013,
       previewUrl:
         "https://p.scdn.co/mp3-preview/79bf6dd5334d98f42c0ada0ce2190aee47be0a8a?cid=abcfcd8269394fd7af92b59a576f5033",
+      artists: [
+        {
+          id: "6HvZYsbFfjnjFrWF950C9d",
+          name: "NewJeans",
+        },
+      ],
       playable: true,
     },
     {
@@ -47,6 +67,12 @@ export const albumDetailDummy: AlbumDetailType = {
       duration: 200266,
       previewUrl:
         "https://p.scdn.co/mp3-preview/18b7e5097ca6b8737678aedeab37a30fe002f4fe?cid=abcfcd8269394fd7af92b59a576f5033",
+      artists: [
+        {
+          id: "6HvZYsbFfjnjFrWF950C9d",
+          name: "NewJeans",
+        },
+      ],
       playable: true,
     },
   ],

--- a/src/dummy/albumReview.ts
+++ b/src/dummy/albumReview.ts
@@ -1,0 +1,16 @@
+import { AlbumReviewType } from "../types/albumReviewType";
+
+export const albumReviewDummy: AlbumReviewType = {
+  id: 10,
+  content: "내용입니다10",
+  score: 1,
+  pros: 10,
+  cons: 0,
+  createdAt: "2024-06-06 00:00:09",
+  reviewer: {
+    id: 10,
+    imageUrl: null,
+    nickname: null,
+    gender: "남성",
+  },
+};

--- a/src/hooks/queries/album.ts
+++ b/src/hooks/queries/album.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getAlbumList, GetAlbumListArgs } from "../../api/album";
+
+export const useAlbumListQuery = (args: GetAlbumListArgs) => {
+  return useQuery({
+    queryKey: ["albumList", args],
+    queryFn: () => getAlbumList(args),
+    enabled: !!args,
+  });
+};

--- a/src/hooks/queries/album.ts
+++ b/src/hooks/queries/album.ts
@@ -1,11 +1,54 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 
-import { getAlbumList, GetAlbumListArgs } from "../../api/album";
+import {
+  getAlbumList,
+  AlbumRequestType,
+  AlbumPageParam,
+  ALBUM_LIST_LIMIT,
+} from "../../api/album";
+import { AlbumType } from "../../types/albumType";
 
-export const useAlbumListQuery = (args: GetAlbumListArgs) => {
+export const useAlbumListQuery = (albumType: AlbumRequestType) => {
   return useQuery({
-    queryKey: ["albumList", args],
-    queryFn: () => getAlbumList(args),
-    enabled: !!args,
+    queryKey: ["albumList", albumType],
+    queryFn: getAlbumList,
+    enabled: !!albumType,
+  });
+};
+
+export const useInfiniteAlbumListQuery = (albumType: AlbumRequestType) => {
+  return useInfiniteQuery({
+    queryKey: ["infiniteAlbumList", albumType],
+    queryFn: getAlbumList,
+    initialPageParam: { cursorId: "", cursorData: "" } as AlbumPageParam,
+    getNextPageParam: (
+      lastPage: AlbumType[], // 마지막 페이지의 데이터
+      _: AlbumType[][], // allPages 모든 페이지들의 데이터
+      lastPageParam: AlbumPageParam // 마지막 페이지의 파라미터
+    ) => {
+      // lastPage: 이전 페이지의 마지막 데이터
+      if (lastPage.length < ALBUM_LIST_LIMIT) {
+        return undefined;
+      }
+
+      const lastData = lastPage[lastPage.length - 1];
+      const cursorId = lastData.id;
+      const cursorData =
+        albumType === "recent"
+          ? lastData.modifiedAt
+          : albumType === "averageScore"
+            ? lastData.averageScore
+            : albumType === "reviewCount"
+              ? lastData.count
+              : "";
+
+      const nextPageParam = { cursorId, cursorData } as AlbumPageParam;
+
+      if (lastPageParam.cursorId === nextPageParam.cursorId) {
+        return undefined;
+      }
+
+      return nextPageParam;
+    },
   });
 };

--- a/src/hooks/queries/albumDetail.ts
+++ b/src/hooks/queries/albumDetail.ts
@@ -1,6 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { getAlbumDetail, getAlbumReviewStatistic } from "../../api/albumDetail";
+import {
+  getAlbumDetail,
+  getAlbumReviewStatistic,
+  getAlbumReviewList,
+  AlbumReviewListArgs,
+} from "../../api/albumDetail";
 
 export const useAlbumDetailQuery = (albumId: string) => {
   return useQuery({
@@ -15,5 +20,13 @@ export const useAlbumReviewStatisticQuery = (albumId: string) => {
     queryKey: ["albumReviewStatistic", albumId],
     queryFn: () => getAlbumReviewStatistic(albumId),
     enabled: !!albumId,
+  });
+};
+
+export const useAlbumReviewListQuery = (args: AlbumReviewListArgs) => {
+  return useQuery({
+    queryKey: ["albumReviewList", args],
+    queryFn: () => getAlbumReviewList(args),
+    enabled: !!args.albumId,
   });
 };

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -44,4 +44,6 @@ export default {
 
   COLOR_GRADIENT_PURPLE: "#5033FF",
   COLOR_GRADIENT_PINK: "#FFA1F6",
+
+  COLOR_BOX_SHADOW_COLOR: "rgba(217, 217, 217, 0.7)",
 };

--- a/src/types/albumDetailType.ts
+++ b/src/types/albumDetailType.ts
@@ -7,6 +7,7 @@ export interface TrackType {
   playable: boolean;
   previewUrl: string;
   duration: number;
+  artists: AlbumArtistType[];
 }
 
 export interface AlbumDetailType {
@@ -15,6 +16,8 @@ export interface AlbumDetailType {
   type: string;
   releasedAt: string;
   trackCount: number;
+  count: number;
+  averageScore: number;
   artists: AlbumArtistType[];
   tracks: TrackType[];
   images: AlbumImageType[];

--- a/src/types/albumReviewType.ts
+++ b/src/types/albumReviewType.ts
@@ -1,0 +1,16 @@
+interface ReviewerType {
+  id: number | string;
+  imageUrl?: null | string;
+  nickname?: null | string;
+  gender: "남성" | "여성" | string;
+}
+
+export interface AlbumReviewType {
+  id: number | string;
+  content: string;
+  score: number;
+  pros: number;
+  cons: number;
+  createdAt: string;
+  reviewer: ReviewerType;
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -3,3 +3,7 @@ import dayjs from "dayjs";
 export const dateFormat = (date: string) => {
   return dayjs(date).format("YYYY-MM-DD");
 };
+
+export const dateTimeFormat = (date: string) => {
+  return dayjs(date).format("YYYY-MM-DD HH:mm:ss");
+};


### PR DESCRIPTION
1. 앨범 감상평 목록 API 연동
- 등록된 감상평이 없는 관계로, 현재 화면에는 보이진 않음
![image](https://github.com/sing-k/FE/assets/79265861/11d752f7-09d2-46cf-aaf3-651ecdb903c0)

2. 게시글 및 댓글 수정/삭제 드롭다운 메뉴 구현
- 게시글 상세 페이지에서 게시글 및 댓글을 관리하기 위한 드롭다운 메뉴 추가
![image](https://github.com/sing-k/FE/assets/79265861/f47d7341-d725-42fe-8530-b21f024b4179)

3. 로딩 및 에러 메시지를 위한 컴포넌트 구현
![image](https://github.com/sing-k/FE/assets/79265861/69c60742-b534-4054-9260-65a277c3d62a)
![image](https://github.com/sing-k/FE/assets/79265861/3f61d3c0-91db-4704-8fa4-2efbfdda2897)

4. AlbumSection 컴포넌트에서 앨범 리스트 데이터 리액트 쿼리로 변경

5. 무한스크롤 기능 구현
- 공부한 내용이랑 구현 방법은 노션에 적어두겠음

![image](https://github.com/sing-k/FE/assets/79265861/b117957b-eb30-4739-b066-3995bf43a515)
