### PR TITLE
마이페이지 내 활동 그래프 및 활동 히스토리 구현 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/styled-components": "5.1.34",
         "axios": "1.6.8",
         "chart.js": "4.4.3",
+        "chartjs-plugin-datalabels": "^2.2.0",
         "dayjs": "1.11.11",
         "http-proxy-middleware": "3.0.0",
         "jwt-decode": "^4.0.0",
@@ -3735,6 +3736,14 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "peerDependencies": {
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/clone": {
@@ -8885,6 +8894,12 @@
       "requires": {
         "@kurkle/color": "^0.3.0"
       }
+    },
+    "chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "requires": {}
     },
     "clone": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/styled-components": "5.1.34",
     "axios": "1.6.8",
     "chart.js": "4.4.3",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "dayjs": "1.11.11",
     "http-proxy-middleware": "3.0.0",
     "jwt-decode": "^4.0.0",

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,6 +1,7 @@
 //회원 관련 api 함수
 import client from "../config/axios";
-
+import { getDefaultDates } from "../utils/date";
+import { ActivityListType } from "../types/activityHistoryType";
 //회원 정보 조회
 export const getMemberInfo = async () => {
   try {
@@ -34,4 +35,36 @@ export const deleteProfileImage = () => {
 //닉네임 수정
 export const updateNickname = ({ newNickname }: { newNickname: string }) => {
   return client.put("/api/members/me", { nickname: newNickname });
+};
+
+export const getHistoryGraph = async (
+  startDate?: string,
+  endDate?: string,
+  type: "DAILY" | "WEEKLY" | "MONTHLY" = "DAILY",
+) => {
+  try {
+    const { startDate: defaultStartDate, endDate: defaultEndDate } =
+      getDefaultDates();
+    const response = await client.get("/api/activity/graph", {
+      params: {
+        startDate: startDate || defaultStartDate,
+        endDate: endDate || defaultEndDate,
+        type,
+      },
+    });
+    return response.data.data;
+  } catch (error) {
+    console.error("활동 그래프를 불러올 수 없습니다.", error);
+    return null;
+  }
+};
+
+export const getActivityList = async (
+  offset: number,
+  limit: number,
+): Promise<ActivityListType> => {
+  const response = await client.get("/api/activity/list", {
+    params: { offset, limit },
+  });
+  return response.data.data;
 };

--- a/src/components/atoms/mypage/DateInput.tsx
+++ b/src/components/atoms/mypage/DateInput.tsx
@@ -1,0 +1,46 @@
+import styled from "styled-components";
+import color from "../../../styles/color";
+interface DateInputProps {
+  label: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  max?: string;
+  min?: string; // min 속성을 선택적으로 받도록 추가
+}
+
+const DateInput = ({ label, value, onChange, max, min }: DateInputProps) => {
+  return (
+    <Container>
+      <Label>{label}</Label>
+      <Input
+        type="date"
+        value={value}
+        onChange={onChange}
+        max={max}
+        min={min}
+      />
+    </Container>
+  );
+};
+
+export default DateInput;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+`;
+const Label = styled.div`
+  text-align: center;
+  font-size: 0.8rem;
+`;
+const Input = styled.input`
+  border: 1px solid ${color.COLOR_DARKGRAY_TEXT};
+  padding: 0.2rem;
+  font-size: 0.8rem;
+  border-radius: 5px;
+  &:focus {
+    outline: none;
+  }
+`;

--- a/src/components/atoms/mypage/TypeSelect.tsx
+++ b/src/components/atoms/mypage/TypeSelect.tsx
@@ -1,0 +1,35 @@
+import styled from "styled-components";
+import color from "../../../styles/color";
+interface TypeSelectProps {
+  value: "DAILY" | "WEEKLY" | "MONTHLY";
+  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+}
+
+const TypeSelect = ({ value, onChange }: TypeSelectProps) => {
+  const options = [
+    { value: "DAILY", label: "일별" },
+    { value: "WEEKLY", label: "주별" },
+    { value: "MONTHLY", label: "월별" },
+  ];
+
+  return (
+    <Select value={value} onChange={onChange}>
+      {options.map(option => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </Select>
+  );
+};
+
+export default TypeSelect;
+
+const Select = styled.select`
+  border: 1px solid ${color.COLOR_DARKGRAY_TEXT};
+  border-radius: 5px;
+  padding: 0.2rem;
+  &:focus {
+    outline: none;
+  }
+`;

--- a/src/components/atoms/mypage/index.ts
+++ b/src/components/atoms/mypage/index.ts
@@ -10,3 +10,5 @@ export { default as MyBoardType } from "./MyBoardType";
 export { default as MyThumbnailImg } from "./MyThumbnailImg";
 export { default as MyThumbnailType } from "./MyThumbnailType";
 export { default as MyGenre } from "./MyGenre";
+export { default as DateInput } from "./DateInput";
+export { default as TypeSelect } from "./TypeSelect";

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,0 +1,91 @@
+import styled from "styled-components";
+import { useMediaQueries } from "../../hooks";
+import { IoIosArrowBack, IoIosArrowForward } from "react-icons/io";
+import color from "../../styles/color";
+interface PaginationProps {
+  currentPage: number; //현재 페이지
+  totalPages: number; // 총 페이지 수
+  onPageChange: (page: number) => void; //페이지 클릭 함수
+}
+
+const Pagination = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: PaginationProps) => {
+  const { isPc, isTablet } = useMediaQueries();
+
+  const pagesToShow = isPc ? 10 : isTablet ? 8 : 5; // 화면 크기에 따른 버튼 개수
+  const startPage = Math.max(
+    0,
+    Math.floor(currentPage / pagesToShow) * pagesToShow,
+  );
+  const endPage = Math.min(totalPages, startPage + pagesToShow);
+  /*
+  startPage ,endPage : 현재 페이지를 기준으로 어떤 페이지 버튼을 보여줄 지
+  예를들어 현재 페이지가 3 일때 startPage = 0 , endPage = 10 으로 1~10까지 보여줌 
+  */
+  const handlePrevGroup = () => {
+    if (startPage > 0) {
+      onPageChange(startPage - pagesToShow);
+    }
+  };
+
+  const handleNextGroup = () => {
+    if (endPage < totalPages) {
+      onPageChange(startPage + pagesToShow);
+    }
+  };
+
+  return (
+    <Container>
+      <Button onClick={handlePrevGroup} disabled={startPage === 0}>
+        <IoIosArrowBack />
+      </Button>
+      {Array.from({ length: endPage - startPage }, (_, index) => (
+        <Button
+          key={startPage + index}
+          onClick={() => onPageChange(startPage + index)}
+          style={{
+            fontWeight: currentPage === startPage + index ? "bold" : "normal",
+            color: currentPage === startPage + index ? "white" : "black",
+            backgroundColor:
+              currentPage === startPage + index
+                ? `${color.COLOR_MAIN}`
+                : "white",
+          }}
+        >
+          {startPage + index + 1}
+        </Button>
+      ))}
+      <Button onClick={handleNextGroup} disabled={endPage >= totalPages}>
+        <IoIosArrowForward />
+      </Button>
+    </Container>
+  );
+};
+
+export default Pagination;
+
+const Container = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 1rem;
+`;
+const Button = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 5px;
+  width: 1.5rem;
+  height: 1.5rem;
+  font-size: 1rem;
+  margin: 0 4px;
+  box-shadow: 1px 1px 1px ${color.COLOR_GRAY_BORDER};
+  &:hover {
+    cursor: pointer;
+  }
+`;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,3 +1,4 @@
 export * from "./MediaQuery";
 export { default as MainLayout } from "./MainLayout";
 export { default as Text } from "./Text";
+export { default as Pagination } from "./Pagination";

--- a/src/components/molecules/mypage/MyActivityGraph.tsx
+++ b/src/components/molecules/mypage/MyActivityGraph.tsx
@@ -1,0 +1,85 @@
+import { Line } from "react-chartjs-2";
+import color from "../../../styles/color";
+import styled from "styled-components";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import ChartDataLabels from "chartjs-plugin-datalabels";
+import { ActivityDataType } from "../../../types/activityHistoryType";
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  ChartDataLabels,
+);
+
+const MyActivityGraph = ({ graph }: { graph: ActivityDataType[] }) => {
+  const data = {
+    labels: graph.map(item => item.date),
+    datasets: [
+      {
+        label: "포인트",
+        data: graph.map(point => point.score),
+        borderColor: `${color.COLOR_LINE_BLUE}`,
+        backgroundColor: `${color.COLOR_LINE_BLUE}`,
+        fill: false,
+        pointBackgroundColor: `${color.COLOR_LINE_BLUE}`,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true, //차트가 반응형으로 동작하게 부모 요소에 맞게
+    plugins: {
+      legend: {
+        display: false,
+        position: "top" as const,
+      },
+      title: {
+        display: false,
+        text: "활동 그래프",
+      },
+      datalabels: {
+        align: "start" as const,
+        anchor: "start" as const,
+        color: "black",
+        formatter: function (value: number) {
+          return value;
+        },
+        clip: false,
+        font: {
+          size: 10,
+        },
+      },
+      layout: {
+        padding: {
+          top: 20, // 차트 상단에 여백을 추가하여 라벨이 더 잘 보이도록 설정
+        },
+      },
+    },
+  };
+
+  return (
+    <Container>
+      <Line data={data} options={options} />
+    </Container>
+  );
+};
+
+export default MyActivityGraph;
+
+const Container = styled.div`
+  background-color: #ffffff7a;
+  padding: 1rem;
+`;

--- a/src/components/molecules/mypage/MyActivityList.tsx
+++ b/src/components/molecules/mypage/MyActivityList.tsx
@@ -1,0 +1,55 @@
+import styled from "styled-components";
+import color from "../../../styles/color";
+import { ListType } from "../../../types/activityHistoryType";
+{
+}
+interface MyActivityListProps {
+  activity: ListType;
+}
+
+const formatScore = (score: number) => {
+  return score >= 0 ? `+${score}` : `${score}`;
+};
+const MyActivityList = ({ activity }: MyActivityListProps) => {
+  const isPositive = activity.score >= 0;
+  return (
+    <Container>
+      <ContentPoint>
+        <Content>{activity.content}</Content>
+        <Score $isPositive={isPositive}>{formatScore(activity.score)}</Score>
+      </ContentPoint>
+      <Date>{activity.date}</Date>
+    </Container>
+  );
+};
+
+export default MyActivityList;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 1rem;
+`;
+const ContentPoint = styled.div`
+  display: flex;
+  justify-content: start;
+  width: 40%;
+`;
+const Content = styled.div`
+  flex: 9;
+  white-space: nowrap;
+  text-align: start;
+`;
+const Score = styled.div<{ $isPositive: boolean }>`
+  flex: 1;
+  width: 20px;
+  text-align: start;
+  color: ${({ $isPositive }) => ($isPositive ? "red" : "blue")}; // 색상 설정
+`;
+const Date = styled.div`
+  color: ${color.COLOR_GRAY_TEXT};
+  text-align: start;
+  font-size: 0.9rem;
+  width: 10rem;
+`;

--- a/src/components/molecules/mypage/index.ts
+++ b/src/components/molecules/mypage/index.ts
@@ -7,3 +7,5 @@ export { default as MyFreeBoardFooter } from "./MyFreeBoardFooter";
 export { default as MyCommentFooter } from "./MyCommentFooter";
 export { default as MyMusicHeader } from "./MyMusicHeader";
 export { default as MyMusicFooter } from "./MyMusicFooter";
+export { default as MyActivityList } from "./MyActivityList";
+export { default as MyActivityGraph } from "./MyActivityGraph";

--- a/src/components/organisms/mypage/ActivityHistoryGraph.tsx
+++ b/src/components/organisms/mypage/ActivityHistoryGraph.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import styled from "styled-components";
+import { useActivityHistoryGraphQuery } from "../../../hooks/queries/user";
+import MyActivityGraph from "../../molecules/mypage/MyActivityGraph";
+import { DateInput, TypeSelect } from "../../atoms";
+import Loading from "../../common/Loading";
+import { getDefaultDates } from "../../../utils/date";
+import ErrorMessage from "../../common/ErrorMessage";
+import color from "../../../styles/color";
+const ActivityHistoryGraph = () => {
+  const { startDate, endDate } = getDefaultDates();
+  const [startDay, setStartDay] = useState<string>(`${startDate}`);
+  const [endDay, setEndDay] = useState<string>(`${endDate}`);
+  const [type, setType] = useState<"DAILY" | "WEEKLY" | "MONTHLY">("DAILY");
+
+  const { data, isLoading, error } = useActivityHistoryGraphQuery(
+    startDay,
+    endDay,
+    type,
+  );
+
+  return (
+    <Container>
+      <ColumnDiv>
+        <Title>활동 그래프</Title>
+        <InputContainer>
+          <DateInput
+            label="조회"
+            value={startDay}
+            onChange={e => setStartDay(e.target.value)}
+            max={endDate}
+          />
+          <DateInput
+            label="~"
+            value={endDay}
+            onChange={e => setEndDay(e.target.value)}
+            max={endDate}
+            min={startDay}
+          />
+          <TypeSelect
+            value={type}
+            onChange={e =>
+              setType(e.target.value as "DAILY" | "WEEKLY" | "MONTHLY")
+            }
+          />
+        </InputContainer>
+      </ColumnDiv>
+      <div>
+        {isLoading ? (
+          <Loading />
+        ) : error ? (
+          <ErrorMessage />
+        ) : data ? (
+          <MyActivityGraph graph={data} />
+        ) : (
+          <ErrorMessage />
+        )}
+      </div>
+    </Container>
+  );
+};
+
+export default ActivityHistoryGraph;
+
+const Title = styled.div`
+  font-size: 1rem;
+  text-align: center;
+  font-weight: 700;
+  white-space: nowrap;
+  color: white;
+  text-shadow: 1px 1px 1px ${color.COLOR_DARKGRAY_TEXT};
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-radius: 5px;
+  border: 1px solid ${color.COLOR_DARKGRAY_TEXT};
+`;
+const ColumnDiv = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid ${color.COLOR_DARKGRAY_TEXT};
+  background-color: ${color.COLOR_MAIN_SKYBLUE};
+  border-radius: 5px 5px 0 0;
+`;
+const InputContainer = styled.div`
+  display: flex;
+  justify-content: end;
+  gap: 1rem;
+`;

--- a/src/components/organisms/mypage/ActivityHistoryList.tsx
+++ b/src/components/organisms/mypage/ActivityHistoryList.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import styled from "styled-components";
+import color from "../../../styles/color";
+import { useActivityListQuery } from "../../../hooks/queries/user";
+import { ListType } from "../../../types/activityHistoryType";
+import { Pagination } from "../../common";
+import { MyActivityList } from "../../molecules";
+import { glassEffectStyle } from "../../../styles/style";
+
+const ActivityHistoryList: React.FC = () => {
+  const [currentPage, setCurrentPage] = useState<number>(0);
+  const limit = 20;
+
+  const offset = currentPage * limit;
+  const { data, isLoading, isError } = useActivityListQuery(offset, limit);
+
+  if (isLoading) return <div>로딩 중...</div>;
+  if (isError) return <div>오류가 발생했습니다.</div>;
+
+  const activities: ListType[] = data?.items || [];
+  const totalCount: number = data?.total || 0;
+  const totalPages = Math.ceil(totalCount / limit);
+
+  return (
+    <Container>
+      <Title>활동 히스토리</Title>
+      <ActivityContainer>
+        {activities.map((activity, index) => (
+          <MyActivityList key={index} activity={activity} />
+        ))}
+      </ActivityContainer>
+      <Div>
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
+      </Div>
+    </Container>
+  );
+};
+
+export default ActivityHistoryList;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-radius: 5px;
+  border: 1px solid ${color.COLOR_DARKGRAY_TEXT};
+`;
+const ActivityContainer = styled.div`
+  ${glassEffectStyle()};
+  padding: 1rem;
+`;
+const Title = styled.div`
+  font-size: 1rem;
+  text-align: center;
+  font-weight: 700;
+  white-space: nowrap;
+  color: white;
+  text-shadow: 1px 1px 1px ${color.COLOR_DARKGRAY_TEXT};
+  padding: 1rem;
+  border-bottom: 1px solid ${color.COLOR_DARKGRAY_TEXT};
+  background-color: ${color.COLOR_MAIN_SKYBLUE};
+  border-radius: 5px 5px 0 0;
+`;
+const Div = styled.div`
+  ${glassEffectStyle()};
+`;

--- a/src/components/organisms/mypage/ActivityHistoryList.tsx
+++ b/src/components/organisms/mypage/ActivityHistoryList.tsx
@@ -63,6 +63,7 @@ const Title = styled.div`
   border-bottom: 1px solid ${color.COLOR_DARKGRAY_TEXT};
   background-color: ${color.COLOR_MAIN_SKYBLUE};
   border-radius: 5px 5px 0 0;
+  text-align: start;
 `;
 const Div = styled.div`
   ${glassEffectStyle()};

--- a/src/components/organisms/mypage/MyActivityHistory.tsx
+++ b/src/components/organisms/mypage/MyActivityHistory.tsx
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+import ActivityHistoryGraph from "./ActivityHistoryGraph";
+import ActivityHistoryList from "./ActivityHistoryList";
+
+const MyActivityHistory = () => {
+  return (
+    <Container>
+      <ActivityHistoryGraph />
+      <ActivityHistoryList />
+    </Container>
+  );
+};
+
+export default MyActivityHistory;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  border-radius: 5px;
+`;

--- a/src/components/organisms/mypage/MyPageTabMenu.tsx
+++ b/src/components/organisms/mypage/MyPageTabMenu.tsx
@@ -16,15 +16,25 @@ const MyPageTabMenu = ({ tabObj, currentTab, onClickTab }: Props) => {
   return (
     <>
       <Container>
-        {Object.keys(tabObj).map(key => (
-          <Tab
-            key={key}
-            className={key === currentTab ? "active" : "none"}
-            onClick={onClickTab.bind(this, key)}
-          >
-            {tabObj[key]} <span>ㅣ {0}</span>
-          </Tab>
-        ))}
+        {Object.keys(tabObj).map(key =>
+          key === "activityHistory" ? (
+            <Tab
+              key={key}
+              className={key === currentTab ? "active" : "none"}
+              onClick={onClickTab.bind(this, key)}
+            >
+              {tabObj[key]}
+            </Tab>
+          ) : (
+            <Tab
+              key={key}
+              className={key === currentTab ? "active" : "none"}
+              onClick={onClickTab.bind(this, key)}
+            >
+              {tabObj[key]} <span>ㅣ {0}</span>
+            </Tab>
+          ),
+        )}
       </Container>
     </>
   );

--- a/src/components/organisms/mypage/index.ts
+++ b/src/components/organisms/mypage/index.ts
@@ -4,3 +4,6 @@ export { default as MyMusicRecommendation } from "./MyMusicRecommendation";
 export { default as MyFreeBoard } from "./MyFreeBoard";
 export { default as MyComment } from "./MyComment";
 export { default as MyPageTabMenu } from "./MyPageTabMenu";
+export { default as MyActivityHistory } from "./MyActivityHistory";
+export { default as ActivityHistoryGraph } from "./ActivityHistoryGraph";
+export { default as ActivityHistoryList } from "./ActivityHistoryList";

--- a/src/components/pages/Mypage.tsx
+++ b/src/components/pages/Mypage.tsx
@@ -11,11 +11,14 @@ import {
   MyComment,
   MyPageTabMenu,
   ProfileEditModal,
+  MyActivityHistory,
 } from "../organisms";
 import { pathName } from "../../App";
 import useModal from "../../hooks/useModal";
 import { useMediaQueries } from "../../hooks";
+
 const tabObj = {
+  activityHistory: "활동 히스토리",
   albumReview: "평가한앨범",
   recommendMusic: "음악추천글",
   freeBoard: "자유글",
@@ -28,7 +31,9 @@ const Mypage = () => {
   const { data } = useMemberInfoQuery();
   const navigate = useNavigate();
   const location = useLocation();
-  const [currentTab, setCurrentTab] = useState<TabKey | string>("albumReview");
+  const [currentTab, setCurrentTab] = useState<TabKey | string>(
+    "activityHistory",
+  );
   const { isOpen, openModal, closeModal } = useModal();
   const { isMobile } = useMediaQueries();
   const onClickTab = (key?: string) => {
@@ -42,7 +47,7 @@ const Mypage = () => {
     if (currentTab) {
       setCurrentTab(currentTab);
     } else {
-      setCurrentTab("albumReview");
+      setCurrentTab("activityHistory");
     }
   }, [location]);
 
@@ -59,6 +64,7 @@ const Mypage = () => {
         />
       </TabContainer>
       <ContentContainer>
+        {currentTab === "activityHistory" && <MyActivityHistory />}
         {currentTab === "albumReview" && <MyAlbumReview />}
         {currentTab === "recommendMusic" && <MyMusicRecommendation />}
         {currentTab === "freeBoard" && <MyFreeBoard />}

--- a/src/hooks/queries/user.ts
+++ b/src/hooks/queries/user.ts
@@ -1,11 +1,21 @@
 //유저 관련 리액트 쿼리
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
+import {
+  ActivityDataType,
+  ActivityListType,
+} from "../../types/activityHistoryType";
 import {
   getMemberInfo,
   uploadProfileImage,
   updateNickname,
   deleteProfileImage,
+  getHistoryGraph,
+  getActivityList,
 } from "../../api/user";
 
 //회원 정보 get
@@ -15,6 +25,7 @@ export const useMemberInfoQuery = () => {
     queryFn: getMemberInfo,
   });
 };
+
 //프로필 이미지 수정
 export const useUploadProfileImageMutation = () => {
   const queryClient = useQueryClient();
@@ -56,5 +67,26 @@ export const useUpdateNicknameMutation = () => {
     onError: error => {
       console.error("닉네임 변경 실패:", error);
     },
+  });
+};
+
+//활동히스토리 그래프 조회
+export const useActivityHistoryGraphQuery = (
+  startDate?: string,
+  endDate?: string,
+  type: "DAILY" | "WEEKLY" | "MONTHLY" = "DAILY",
+) => {
+  return useQuery<ActivityDataType[], Error>({
+    queryKey: ["historyGraph", { startDate, endDate, type }],
+    queryFn: () => getHistoryGraph(startDate, endDate, type),
+    enabled: !!startDate && !!endDate,
+  });
+};
+
+export const useActivityListQuery = (offset: number, limit: number) => {
+  return useQuery<ActivityListType, Error>({
+    queryKey: ["activityList", offset, limit],
+    queryFn: () => getActivityList(offset, limit),
+    placeholderData: keepPreviousData,
   });
 };

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -46,4 +46,6 @@ export default {
   COLOR_GRADIENT_PINK: "#FFA1F6",
 
   COLOR_BOX_SHADOW_COLOR: "rgba(217, 217, 217, 0.7)",
+
+  COLOR_LINE_BLUE: "#5033FF",
 };

--- a/src/types/activityHistoryType.ts
+++ b/src/types/activityHistoryType.ts
@@ -1,0 +1,16 @@
+export interface ActivityDataType {
+  date: string;
+  score: number;
+}
+
+export interface ListType {
+  content: string;
+  score: number;
+  date: string;
+}
+
+export interface ActivityListType {
+  items: ListType[];
+  limit: number;
+  total: number;
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -7,3 +7,12 @@ export const dateFormat = (date: string) => {
 export const dateTimeFormat = (date: string) => {
   return dayjs(date).format("YYYY-MM-DD HH:mm:ss");
 };
+
+export const getDefaultDates = () => {
+  const endDate = dayjs();
+  const startDate = endDate.subtract(7, "day");
+  return {
+    startDate: dateFormat(startDate.toISOString()),
+    endDate: dateFormat(endDate.toISOString()),
+  };
+};


### PR DESCRIPTION
1. 활동 그래프 구현 
api가 시작 날짜와 끝 날짜를 포함해서 api를 요청하게 만들어져있음 
기본적으로 마이페이지에 들어왔을 땐 현재 날짜로부터 일주일 날짜를 구해서 일주일 일별 활동 그래프를 보여줌 (디폴트)
그 외 사용자가 시작 날짜와 끝 날짜를 선택해서 원하는 범위를 확인할 수 있음 
(반응형으로는 아직 미구현 pc만 구현됨 모바일에선 어떻게 할지 고민중 ,, ) 

![Jul-24-2024 16-01-37](https://github.com/user-attachments/assets/b9ccdf40-5e89-4ba8-b6da-0e28ca49864b)

2. 활동 히스토리 구현  (제목 왼쪽 정렬되어있음 !!  움짤이랑은 다름 ) 
페이지네이션으로 구현 ( pc화면에서는 버튼이 10개까지 태블릿에서는 8개 모바일에서는 5개  ) -> 공통 파일로 제작해놨음 
기본적으로 한페이지내에 20개의 활동이 보이고 획득한 점수는 빨간색 차감된 점수는 파란색으로 나타냈음 

![Jul-24-2024 16-02-57](https://github.com/user-attachments/assets/e7883796-6aa7-4951-8053-79d9ab09fb11)


